### PR TITLE
Fix non-thermal excitation cross section and low-energy Coulomb logarithm (ARTIS #452)

### DIFF
--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -31,7 +31,7 @@ def electronlossfunction(energy_ev: float, n_e_cgs: float) -> float:
         assert 2 * energy > zetae
         lossfunc = n_e * 2 * math.pi * QE**4 / energy * math.log(2 * energy / zetae)
     else:
-        v = math.sqrt(2 * energy / ME)  # velocity in m/s
+        v = math.sqrt(2 * energy / ME)  # velocity in cm/s (energy is in erg and ME in g, so cgs)
         # Kozma & Fransson (1992) eq. 2 describes the gamma in this Coulomb logarithm as "Euler's
         # constant (Schunk & Hays 1971)", but Schunk & Hays (1971, p. 114) define it by "ln gamma is
         # Euler's constant", i.e. gamma = exp(0.5772) = 1.781 rather than 0.5772 itself.

--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -32,8 +32,13 @@ def electronlossfunction(energy_ev: float, n_e_cgs: float) -> float:
         lossfunc = n_e * 2 * math.pi * QE**4 / energy * math.log(2 * energy / zetae)
     else:
         v = math.sqrt(2 * energy / ME)  # velocity in m/s
-        eulergamma = 0.577215664901532
-        lossfunc = n_e * 2 * math.pi * QE**4 / energy * math.log(ME * pow(v, 3) / (eulergamma * pow(QE, 2) * omegap))
+        # Kozma & Fransson (1992) eq. 2 describes the gamma in this Coulomb logarithm as "Euler's
+        # constant (Schunk & Hays 1971)", but Schunk & Hays (1971, p. 114) define it by "ln gamma is
+        # Euler's constant", i.e. gamma = exp(0.5772) = 1.781 rather than 0.5772 itself.
+        exp_eulergamma = math.exp(np.euler_gamma)
+        lossfunc = (
+            n_e * 2 * math.pi * QE**4 / energy * math.log(ME * pow(v, 3) / (exp_eulergamma * pow(QE, 2) * omegap))
+        )
 
     # lossfunc is now [erg / cm]
     return lossfunc / EV  # return as [eV / cm]

--- a/pynonthermal/excitation.py
+++ b/pynonthermal/excitation.py
@@ -12,8 +12,6 @@ from pynonthermal.constants import H_ionpot
 from pynonthermal.constants import ME
 from pynonthermal.constants import QE
 
-use_collstrengths = False
-
 
 def get_xs_excitation(en_ev: float, row: dict[str, t.Any]) -> float:
     """Get the excitation cross section in cm^2 at energy en_ev [eV]."""
@@ -27,12 +25,13 @@ def get_xs_excitation(en_ev: float, row: dict[str, t.Any]) -> float:
     if en_ev < epsilon_trans_ev:
         return 0.0
 
-    if coll_str >= 0 and use_collstrengths:
+    if coll_str >= 0:
         # collision strength is available, so use it
-        # Li et al. 2012 equation 11
-        constantfactor = pow(H_ionpot, 2) / row["lower_g"] * coll_str * math.pi * A_naught_squared
+        # Li et al. 2012 equation 11: sigma = pi * a_0^2 * (H_ionpot / E) * coll_str / lower_g,
+        # with k_i^2 = E / H_ionpot in units of the inverse Bohr radius squared
+        constantfactor = H_ionpot / row["lower_g"] * coll_str * math.pi * A_naught_squared
 
-        return constantfactor * (en_ev * EV) ** -2
+        return constantfactor / (en_ev * EV)
 
     if not row["forbidden"]:
         nu_trans = epsilon_trans / H
@@ -71,12 +70,13 @@ def get_xs_excitation_vector(engrid: npt.NDArray[np.float64], row: dict[str, t.A
     startindex = pynonthermal.get_energyindex_gteq(en_ev=epsilon_trans_ev, engrid=engrid)
     xs_excitation_vec[:startindex] = 0.0
 
-    if coll_str >= 0 and use_collstrengths:
+    if coll_str >= 0:
         # collision strength is available, so use it
-        # Li et al. 2012 equation 11
-        constantfactor = pow(H_ionpot, 2) / row["lower_g"] * coll_str * math.pi * A_naught_squared
+        # Li et al. 2012 equation 11: sigma = pi * a_0^2 * (H_ionpot / E) * coll_str / lower_g,
+        # with k_i^2 = E / H_ionpot in units of the inverse Bohr radius squared
+        constantfactor = H_ionpot / row["lower_g"] * coll_str * math.pi * A_naught_squared
 
-        xs_excitation_vec[startindex:] = constantfactor * (engrid[startindex:] * EV) ** -2
+        xs_excitation_vec[startindex:] = constantfactor / (engrid[startindex:] * EV)
 
     elif not row["forbidden"]:
         nu_trans = epsilon_trans / H

--- a/pynonthermal/excitation.py
+++ b/pynonthermal/excitation.py
@@ -12,6 +12,8 @@ from pynonthermal.constants import H_ionpot
 from pynonthermal.constants import ME
 from pynonthermal.constants import QE
 
+use_collstrengths = False
+
 
 def get_xs_excitation(en_ev: float, row: dict[str, t.Any]) -> float:
     """Get the excitation cross section in cm^2 at energy en_ev [eV]."""
@@ -25,7 +27,7 @@ def get_xs_excitation(en_ev: float, row: dict[str, t.Any]) -> float:
     if en_ev < epsilon_trans_ev:
         return 0.0
 
-    if coll_str >= 0:
+    if coll_str >= 0 and use_collstrengths:
         # collision strength is available, so use it
         # Li et al. 2012 equation 11: sigma = pi * a_0^2 * (H_ionpot / E) * coll_str / lower_g,
         # with k_i^2 = E / H_ionpot in units of the inverse Bohr radius squared
@@ -70,7 +72,7 @@ def get_xs_excitation_vector(engrid: npt.NDArray[np.float64], row: dict[str, t.A
     startindex = pynonthermal.get_energyindex_gteq(en_ev=epsilon_trans_ev, engrid=engrid)
     xs_excitation_vec[:startindex] = 0.0
 
-    if coll_str >= 0:
+    if coll_str >= 0 and use_collstrengths:
         # collision strength is available, so use it
         # Li et al. 2012 equation 11: sigma = pi * a_0^2 * (H_ionpot / E) * coll_str / lower_g,
         # with k_i^2 = E / H_ionpot in units of the inverse Bohr radius squared

--- a/pynonthermal/tests/test_sfsolve.py
+++ b/pynonthermal/tests/test_sfsolve.py
@@ -10,10 +10,7 @@ outputfolder = Path(__file__).absolute().parent / "output"
 
 
 def test_helium() -> None:
-    # Pure-Helium Plasma, in the setup of KF1992 Figure 3.
-    # NB: the expected values below are regression values from this code, not the KF1992 result.
-    # They stopped matching KF1992 Fig. 3 (frac_excitation 0.3315, frac_ionisation 0.4849) when the
-    # collision-strength cross sections were enabled for transitions that KF1992 treated otherwise.
+    # KF1992 Figure 3. Pure-Helium Plasma
     x_e = 1e-4
     ions = [
         # Z ion_stage numberdensity
@@ -37,9 +34,9 @@ def test_helium() -> None:
 
         frac_sum = frac_excitation_tot + frac_ionisation_tot + frac_heating
         assert math.isclose(frac_sum, 1.0, abs_tol=0.005)
-        assert math.isclose(frac_excitation_tot, 0.1356, abs_tol=0.05)
-        assert math.isclose(frac_ionisation_tot, 0.6202, abs_tol=0.05)
-        assert math.isclose(sf.get_frac_ionisation_ion(Z=ions[0][0], ion_stage=ions[0][1]), 0.6202, abs_tol=0.05)
+        assert math.isclose(frac_excitation_tot, 0.3315, abs_tol=0.05)
+        assert math.isclose(frac_ionisation_tot, 0.4849, abs_tol=0.05)
+        assert math.isclose(sf.get_frac_ionisation_ion(Z=ions[0][0], ion_stage=ions[0][1]), 0.4807, abs_tol=0.05)
         assert math.isclose(sf.get_frac_ionisation_ion(Z=ions[1][0], ion_stage=ions[1][1]), 0.0, abs_tol=0.05)
 
         sf.plot_spec_channels(outputfilename=outputfolder / "spec_channels.pdf", xscalelog=True)
@@ -66,13 +63,13 @@ def test_iron() -> None:
 
         frac_sum = frac_excitation_tot + frac_ionisation_tot + frac_heating
         assert math.isclose(frac_sum, 1.0, abs_tol=0.005)
-        assert math.isclose(frac_excitation_tot, 0.00555, rel_tol=0.05)
-        assert math.isclose(frac_ionisation_tot, 0.1738, abs_tol=0.05)
+        assert math.isclose(frac_excitation_tot, 0.0204, abs_tol=0.05)
+        assert math.isclose(frac_ionisation_tot, 0.1391, abs_tol=0.05)
 
-        assert math.isclose(sf.get_ionisation_ratecoeff(26, 2), 4.42e-01, rel_tol=0.05)
-        assert math.isclose(sf.get_ionisation_ratecoeff(26, 3), 3.69e-01, rel_tol=0.05)
+        assert math.isclose(sf.get_ionisation_ratecoeff(26, 2), 4.44e-01, rel_tol=0.05)
+        assert math.isclose(sf.get_ionisation_ratecoeff(26, 3), 3.70e-01, rel_tol=0.05)
 
-        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (0, 100)), 3.9719740070759065e-07, rel_tol=0.05)
-        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (1, 100)), 6.619054348580435e-08, rel_tol=0.05)
+        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (0, 100)), 3.9930269946568673e-07, rel_tol=0.05)
+        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (1, 100)), 6.654239325994856e-08, rel_tol=0.05)
 
         sf.plot_spec_channels(outputfilename=outputfolder / "spec_channels.pdf", xscalelog=True)

--- a/pynonthermal/tests/test_sfsolve.py
+++ b/pynonthermal/tests/test_sfsolve.py
@@ -10,7 +10,10 @@ outputfolder = Path(__file__).absolute().parent / "output"
 
 
 def test_helium() -> None:
-    # KF1992 Figure 3. Pure-Helium Plasma
+    # Pure-Helium Plasma, in the setup of KF1992 Figure 3.
+    # NB: the expected values below are regression values from this code, not the KF1992 result.
+    # They stopped matching KF1992 Fig. 3 (frac_excitation 0.3315, frac_ionisation 0.4849) when the
+    # collision-strength cross sections were enabled for transitions that KF1992 treated otherwise.
     x_e = 1e-4
     ions = [
         # Z ion_stage numberdensity
@@ -34,9 +37,9 @@ def test_helium() -> None:
 
         frac_sum = frac_excitation_tot + frac_ionisation_tot + frac_heating
         assert math.isclose(frac_sum, 1.0, abs_tol=0.005)
-        assert math.isclose(frac_excitation_tot, 0.3315, abs_tol=0.05)
-        assert math.isclose(frac_ionisation_tot, 0.4849, abs_tol=0.05)
-        assert math.isclose(sf.get_frac_ionisation_ion(Z=ions[0][0], ion_stage=ions[0][1]), 0.4807, abs_tol=0.05)
+        assert math.isclose(frac_excitation_tot, 0.1356, abs_tol=0.05)
+        assert math.isclose(frac_ionisation_tot, 0.6202, abs_tol=0.05)
+        assert math.isclose(sf.get_frac_ionisation_ion(Z=ions[0][0], ion_stage=ions[0][1]), 0.6202, abs_tol=0.05)
         assert math.isclose(sf.get_frac_ionisation_ion(Z=ions[1][0], ion_stage=ions[1][1]), 0.0, abs_tol=0.05)
 
         sf.plot_spec_channels(outputfilename=outputfolder / "spec_channels.pdf", xscalelog=True)
@@ -63,13 +66,13 @@ def test_iron() -> None:
 
         frac_sum = frac_excitation_tot + frac_ionisation_tot + frac_heating
         assert math.isclose(frac_sum, 1.0, abs_tol=0.005)
-        assert math.isclose(frac_excitation_tot, 0.0204, abs_tol=0.05)
-        assert math.isclose(frac_ionisation_tot, 0.1391, abs_tol=0.05)
+        assert math.isclose(frac_excitation_tot, 0.00555, rel_tol=0.05)
+        assert math.isclose(frac_ionisation_tot, 0.1738, abs_tol=0.05)
 
-        assert math.isclose(sf.get_ionisation_ratecoeff(26, 2), 4.44e-01, rel_tol=0.05)
-        assert math.isclose(sf.get_ionisation_ratecoeff(26, 3), 3.70e-01, rel_tol=0.05)
+        assert math.isclose(sf.get_ionisation_ratecoeff(26, 2), 4.42e-01, rel_tol=0.05)
+        assert math.isclose(sf.get_ionisation_ratecoeff(26, 3), 3.69e-01, rel_tol=0.05)
 
-        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (0, 100)), 3.9930269946568673e-07, rel_tol=0.05)
-        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (1, 100)), 6.654239325994856e-08, rel_tol=0.05)
+        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (0, 100)), 3.9719740070759065e-07, rel_tol=0.05)
+        assert math.isclose(sf.get_excitation_ratecoeff(26, 2, (1, 100)), 6.619054348580435e-08, rel_tol=0.05)
 
         sf.plot_spec_channels(outputfilename=outputfolder / "spec_channels.pdf", xscalelog=True)


### PR DESCRIPTION
Ports the two physics corrections from [artis-mcrt/artis#452](https://github.com/artis-mcrt/artis/pull/452), which called out pynonthermal as carrying both of the same expressions.

Both expressions are now correct and consistent with ARTIS. **Neither changes any result today** — see "What this actually changes" below. The `use_collstrengths` gate is deliberately left in place, so enabling collision strengths stays a separate, separately-validated decision.

## 1. Excitation cross section from collision strengths

`get_xs_excitation()` and `get_xs_excitation_vector()` both used `pow(H_ionpot, 2)` with a `1/E^2` energy dependence. Li, Dessart & Hillier (2012) eq. 11 gives `Q_ij = (1/k_i^2)(1/w_i) Omega_ij pi a_0^2` with `k_i^2 = E / I_H`, so the cross section is **linear** in `I_H / E`:

```
Q_ij = pi a_0^2 (I_H / E) Omega_ij / g_lower
```

Verified by calling the functions directly with the gate forced open: the cross section scales as 1/E, the scalar and vector implementations agree to 1e-12, and the correction factor is `E / 13.6 eV` — 7.35x at 100 eV, 73.5x at 1 keV, 0.74x below 13.6 eV, matching the ARTIS PR's stated magnitudes.

The van Regemorter/Mewe branch used for permitted lines is unchanged.

## 2. Euler's constant not exponentiated in the sub-14 eV Coulomb logarithm

`electronlossfunction()` used `eulergamma = 0.5772` directly in `ln[m v^3 / (gamma e^2 omega_p)]`, but the `gamma` here is the *exponentiated* constant. Schunk & Hays (1971, p. 114) define the symbols of their eq. 4 with "ln gamma is Euler's constant", i.e. `gamma = exp(0.5772) = 1.781`. Kozma & Fransson (1992) eq. 2 paraphrase this as "gamma is Euler's constant", dropping the "ln", which is what invited the error.

Unlike ARTIS — which had to hardcode `EXP_EULERGAMMA` because `std::exp` is not constexpr in libc++ — this uses `math.exp(np.euler_gamma)` directly, which evaluates to 1.7810724179901980 (matching ARTIS's literal to every digit) and makes the exponentiation self-evident.

**Effect in isolation:** the loss rate below 14 eV drops by **5–8%** (−5.8% at 5 eV, n_e=1e6), rising with density. Note this is smaller than the "roughly 10-20%" quoted in the ARTIS PR description — the direction and the factor-3.08 change in the log argument are exactly as described, but the quoted percentage looks overstated, since the relative effect depends on how close the log argument sits to unity. Worth correcting there.

Also fixes an adjacent comment that described `v` as m/s; `energy` is in erg and `ME` in g, so it is cm/s like the rest of the cgs module (thanks Copilot). The arithmetic was always right.

## What this actually changes: nothing, yet

Running both benchmarks on `main` and on this branch gives **bit-identical** results:

| | frac_exc | frac_ion | frac_heat |
|---|---|---|---|
| helium (main and this branch) | 0.32379819399683457 | 0.4808712811755063 | 0.19544278670999643 |
| iron (main and this branch) | 0.02183727398727628 | 0.17109470653740358 | 0.8097214854182093 |

Reference values in `test_sfsolve.py` are therefore untouched and both tests pass. The two fixes are inert for different reasons, and it's worth being explicit that **neither is currently covered by the test suite**:

- **Fix 1 is dead code.** `use_collstrengths = False`, so the collision-strength branch never executes. This is what codecov is reporting as 0% patch coverage on `excitation.py` — the report is accurate, not stale.
- **Fix 2 executes but is numerically irrelevant here.** Only 9 of the 2000 grid points fall below 14 eV, and both benchmarks run at n_e ~1e-4, making the loss term ~1e-16 — far too small to move the solution. Substituting an absurd `gamma = 1e6` leaves both benchmarks unchanged to all printed digits, so this is a property of the test configurations rather than of the fix.

## Why the gate stays closed

Opening it is a physics decision, not a code one. Forcing it open gives:

| variant | frac_exc | frac_ion | frac_heat | sum |
|---|---|---|---|---|
| KF1992 Fig. 3 (what the He test encodes) | 0.3315 | 0.4849 | | |
| A: collstr OFF (this branch) | 0.3238 | 0.4809 | 0.1954 | 1.0001 |
| B: collstr ON + old squared formula | 0.1014 | 0.6428 | 0.2557 | 1.0000 |
| C: collstr ON + fixed linear formula | 0.1356 | 0.6202 | 0.2442 | 1.0000 |

With collision strengths live, He stops reproducing Kozma & Fransson 1992 Fig. 3 (`frac_excitation` 0.3315 → 0.1356) because the He collision-strength data takes precedence over the path KF1992 used. That happens either way — B is further from the benchmark than C — so it is caused by enabling the branch, not by the formula fix.

The fix does behave exactly as ARTIS predicted, though: B → C raises `frac_excitation` (0.1014 → 0.1356) and drops `frac_heating` (0.2557 → 0.2442), which is the "larger frac_excitation, corresponding drop in frac_heating" the ARTIS PR describes, with `frac_sum` staying at 1.0000.

So this PR gets the expressions right and leaves the gate closed; enabling it can be validated on its own footing, where the KF1992 disagreement is the question to answer rather than a side effect.

ruff, ty, and mypy are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
