### PR TITLE
Make use_collstrengths a parameter instead of a module global

### DIFF
--- a/pynonthermal/excitation.py
+++ b/pynonthermal/excitation.py
@@ -12,10 +12,8 @@ from pynonthermal.constants import H_ionpot
 from pynonthermal.constants import ME
 from pynonthermal.constants import QE
 
-use_collstrengths = False
 
-
-def get_xs_excitation(en_ev: float, row: dict[str, t.Any]) -> float:
+def get_xs_excitation(en_ev: float, row: dict[str, t.Any], use_collstrengths: bool = True) -> float:
     """Get the excitation cross section in cm^2 at energy en_ev [eV]."""
     A_naught_squared = 2.800285203e-17  # Bohr radius squared in cm^2
 
@@ -58,7 +56,9 @@ def get_xs_excitation(en_ev: float, row: dict[str, t.Any]) -> float:
     return 0.0
 
 
-def get_xs_excitation_vector(engrid: npt.NDArray[np.float64], row: dict[str, t.Any]) -> npt.NDArray[np.float64]:
+def get_xs_excitation_vector(
+    engrid: npt.NDArray[np.float64], row: dict[str, t.Any], use_collstrengths: bool = True
+) -> npt.NDArray[np.float64]:
     """Get an array containing the excitation cross section in cm^2 at every energy in the array engrid (eV)."""
     A_naught_squared = 2.800285203e-17  # Bohr radius squared in cm^2
     npts = len(engrid)

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -211,7 +211,13 @@ class SpencerFanoSolver:
             )
 
     def add_ion_ltepopexcitation(
-        self, Z: int, ion_stage: int, n_ion: float, temperature: float = 3000, adata_polars: pl.DataFrame | None = None
+        self,
+        Z: int,
+        ion_stage: int,
+        n_ion: float,
+        temperature: float = 3000,
+        adata_polars: pl.DataFrame | None = None,
+        use_collstrengths: bool = True,
     ) -> None:
         if adata_polars is not None:
             self.adata_polars = adata_polars
@@ -285,7 +291,9 @@ class SpencerFanoSolver:
             for transition in dftransitions.iter_rows(named=True):
                 epsilon_trans_ev = transition["epsilon_trans_ev"]
                 if epsilon_trans_ev >= self.engrid[0]:
-                    xs_vec = pynonthermal.excitation.get_xs_excitation_vector(self.engrid, transition)
+                    xs_vec = pynonthermal.excitation.get_xs_excitation_vector(
+                        self.engrid, transition, use_collstrengths=use_collstrengths
+                    )
                     self.add_excitation(
                         Z,
                         ion_stage,

--- a/pynonthermal/tests/test_sfsolve.py
+++ b/pynonthermal/tests/test_sfsolve.py
@@ -21,7 +21,7 @@ def test_helium() -> None:
     with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=2000, verbose=True) as sf:
         for Z, ion_stage, n_ion in ions:
             sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
-            sf.add_ion_ltepopexcitation(Z, ion_stage, n_ion=n_ion)
+            sf.add_ion_ltepopexcitation(Z, ion_stage, n_ion=n_ion, use_collstrengths=False)
 
         # call solve twice to test that it can be called multiple times without error
         sf.solve(depositionratedensity_ev=1000)
@@ -52,7 +52,7 @@ def test_iron() -> None:
     with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=16000, npts=1024, verbose=True) as sf:
         for Z, ion_stage, n_ion in ions:
             sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
-            sf.add_ion_ltepopexcitation(Z, ion_stage, n_ion=n_ion)
+            sf.add_ion_ltepopexcitation(Z, ion_stage, n_ion=n_ion, use_collstrengths=False)
 
         sf.solve(depositionratedensity_ev=100)
 


### PR DESCRIPTION
Replace the module-level `use_collstrengths` flag in excitation.py with a
parameter on the excitation cross-section helpers (get_xs_excitation,
get_xs_excitation_vector) and on add_ion_ltepopexcitation, defaulting to True.

Set use_collstrengths=False in the helium and iron benchmark tests to preserve
their current outputs (the previous global defaulted to False).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WQQBcQ3NSPs8zfQiVFsjv8