### PR TITLE
Restrict package contents to runtime files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,7 @@
 include LICENSE
 include README.md
 include pynonthermal/py.typed
-recursive-include pynonthermal/data *.txt *.zst
 
 prune pynonthermal/tests
 global-exclude *.py[cod]
-global-exclude __pycache__
 global-exclude .DS_Store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,9 @@
-recursive-include pynonthermal *.*
-include requirements.txt
-include LICENCE
+include LICENSE
 include README.md
+include pynonthermal/py.typed
+recursive-include pynonthermal/data *.txt *.zst
+
+prune pynonthermal/tests
+global-exclude *.py[cod]
+global-exclude __pycache__
+global-exclude .DS_Store


### PR DESCRIPTION
## Summary

- replace broad recursive package inclusion with the source-controlled file list provided by `setuptools-scm`
- keep tests, bytecode, Finder metadata, generated PDFs, and nested build metadata out of distributions
- include future tracked atomic-data formats without maintaining an extension allowlist
- correct the manifest entries for `LICENSE` and `README.md`

## Root cause and impact

`recursive-include pynonthermal *.*` treated every file below the package directory as package data. As a result, a build from a normal development checkout could silently publish ignored local artifacts. The wheel now contains only the Python modules, `py.typed`, source-controlled atomic-data files, and standard wheel metadata.

## Validation

- built an sdist and wheel from a checkout containing the reproduced ignored artifacts
- audited both archives: no package `__pycache__`, `.pyc`, `.DS_Store`, tests, generated PDFs, or nested `pynonthermal.egg-info`
- compared the wheel against all tracked non-test package files; no runtime files are missing
- installed the wheel into an isolated target and loaded all 20 packaged atomic-data files, including both collisional datasets and the ARTIS excitation tree
- `python -m pytest -n 0 --cov=./ --cov-report=term-missing` (16 passed, 98% coverage)
- `ruff check --exit-non-zero-on-fix --no-fix`
- `ruff format --check --exit-non-zero-on-format`
- `mypy`
- `basedpyright --warnings`
- `pyrefly check`
- commit-time pre-commit checks