### PR TITLE
Resolve the Kozma & Fransson eq. 6 integrals and validate solver inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ Ionization cross sections from H (Z=1) to Ni (Z=28) are sourced from the analyti
 You can supply your own excitation cross section table:
 
 ```python
-sf.add_excitation(Z, ion_stage, n_level, xs_vec, epsilon_trans_ev, transitionkey=(lower, upper))
+sf.add_excitation(Z, ion_stage, levelnumberdensity, xs_vec, epsilon_trans_ev, transitionkey=(lower, upper))
 ```
 
 - `Z`: atomic number.
 - `ion_stage`: one more than ion charge.
-- `n_level`: population density of the lower level (cm^-3), non-negative.
+- `levelnumberdensity`: population density of the lower level (cm^-3), non-negative.
 - `xs_vec`: NumPy array of cross sections (cm^2), non-negative, defined at every energy in `sf.engrid` (eV).
 - `epsilon_trans_ev`: transition energy (eV). Must be positive and no greater than `emax_ev`, since no
   electron the solver represents could otherwise drive the transition.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,15 @@ sf.add_excitation(Z, ion_stage, n_level, xs_vec, epsilon_trans_ev, transitionkey
 
 - `Z`: atomic number.
 - `ion_stage`: one more than ion charge.
-- `xs_vec`: NumPy array of cross sections (cm^2), defined at every energy in `sf.engrid` (eV).
+- `n_level`: population density of the lower level (cm^-3), non-negative.
+- `xs_vec`: NumPy array of cross sections (cm^2), non-negative, defined at every energy in `sf.engrid` (eV).
+- `epsilon_trans_ev`: transition energy (eV). Must be positive and no greater than `emax_ev`, since no
+  electron the solver represents could otherwise drive the transition.
 - `transitionkey`: any unique key within the ion, used to retrieve the excitation rate coefficient.
+
+Transitions below `emin_ev` are allowed here, but `add_ion_ltepopexcitation()` drops them: Kozma and
+Fransson (1992) take every electron below `emin_ev` to have thermalised, so that energy is accounted for
+as heating instead.
 
 Retrieve the non-thermal excitation rate coefficient [s^-1] with:
 

--- a/pynonthermal/__init__.py
+++ b/pynonthermal/__init__.py
@@ -1,5 +1,6 @@
 from pynonthermal import axelrod as axelrod
 from pynonthermal import collion as collion
+from pynonthermal import constants as constants
 from pynonthermal import excitation as excitation
 from pynonthermal.base import DATADIR as DATADIR
 from pynonthermal.base import electronlossfunction as electronlossfunction

--- a/pynonthermal/__init__.py
+++ b/pynonthermal/__init__.py
@@ -1,4 +1,5 @@
 from pynonthermal import axelrod as axelrod
+from pynonthermal import base as base
 from pynonthermal import collion as collion
 from pynonthermal import constants as constants
 from pynonthermal import excitation as excitation

--- a/pynonthermal/axelrod.py
+++ b/pynonthermal/axelrod.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.typing as npt
 
 import pynonthermal
+from pynonthermal.base import get_betasq
 from pynonthermal.constants import CLIGHT
 from pynonthermal.constants import EV
 from pynonthermal.constants import ME
@@ -61,9 +62,13 @@ def get_shell_configs() -> npt.NDArray[np.int64]:
     return shells_q
 
 
-def get_shell_occupancies(
-    atomic_number: int, ion_stage: int, electron_binding: npt.NDArray[np.float64], all_shells_q: npt.NDArray[np.int64]
-) -> npt.NDArray[np.int64]:
+@lru_cache
+def get_shell_occupancies(atomic_number: int, ion_stage: int) -> npt.NDArray[np.int64]:
+    # electrons in each shell of one ion, taken from the neutral configuration with the outermost
+    # electrons removed. Cached, like the two tables it reads, because every ionisation cross section
+    # evaluation needs it and it depends only on the ion.
+    electron_binding = get_binding_energies()
+    all_shells_q = get_shell_configs()
     nbound = atomic_number - ion_stage + 1
     element_shells_q_neutral = all_shells_q[atomic_number - 1]
     shellcount = min(len(element_shells_q_neutral), len(electron_binding[atomic_number - 1]))
@@ -91,8 +96,7 @@ def get_shell_occupancies(
 def get_sum_q_over_binding_energy(atomic_number: int, ion_stage: int, ionpot_ev: float) -> float:
     # LJS: translated from artis nonthermal.cc
     electron_binding = get_binding_energies()
-    all_shells_q = get_shell_configs()
-    q = get_shell_occupancies(atomic_number, ion_stage, electron_binding, all_shells_q)
+    q = get_shell_occupancies(atomic_number, ion_stage)
 
     total = 0.0
     for electron_loop in range(q.size):
@@ -129,20 +133,16 @@ def get_lotz_xs_ionisation_vec(
 
     arr_en_erg = arr_en_ev * EV
 
-    # relativistic, to match the relativistic correction terms in the Axelrod equation below.
-    # The classical betasq = 2 * en_erg / (ME * CLIGHT**2) reaches one at 255 keV, above which every
-    # cross section was silently set to zero, and is already 5% high at 16 keV and 30% high at 100 keV.
-    gamma = arr_en_erg / (ME * CLIGHT**2) + 1.0
-    betasq = 1.0 - 1.0 / gamma**2
+    # relativistic, to match the relativistic correction terms in the Axelrod equation below. The
+    # classical form reaches one at 255 keV, above which every cross section was silently set to zero.
+    betasq = get_betasq(arr_en_ev)
 
     atomic_number = int(shell["Z"])
     ion_stage = int(shell["ion_stage"])
     ionpot_ev = shell["ionpot_ev"]
     shellindex = -int(shell["l"])
 
-    electron_binding = get_binding_energies()
-    all_shells_q = get_shell_configs()
-    electronsinshell = get_shell_occupancies(atomic_number, ion_stage, electron_binding, all_shells_q)[shellindex]
+    electronsinshell = get_shell_occupancies(atomic_number, ion_stage)[shellindex]
 
     p = ionpot_ev * EV
     Aconst = 1.33e-14 * EV * EV

--- a/pynonthermal/axelrod.py
+++ b/pynonthermal/axelrod.py
@@ -1,6 +1,7 @@
 # functions related to Axelrod 1980 non-thermal treatment
 
 import math
+from functools import cache
 from functools import lru_cache
 from pathlib import Path
 
@@ -35,6 +36,9 @@ def get_binding_energies() -> npt.NDArray[np.float64]:
             assert int(linesplit[0]) == i + 1
             electron_binding[i] = np.array([float(x) for x in linesplit[1:]]) * EV
 
+    # handed straight to callers from the cache, so a write must raise at the mutation site
+    electron_binding.flags.writeable = False
+
     return electron_binding
 
 
@@ -59,10 +63,13 @@ def get_shell_configs() -> npt.NDArray[np.int64]:
             shells_q[i, :] = np.array([int(x) for x in linesplit[1:]])
             assert sum(shells_q[i]) == i + 1
 
+    # handed straight to callers from the cache, so a write must raise at the mutation site
+    shells_q.flags.writeable = False
+
     return shells_q
 
 
-@lru_cache
+@cache
 def get_shell_occupancies(atomic_number: int, ion_stage: int) -> npt.NDArray[np.int64]:
     # electrons in each shell of one ion, taken from the neutral configuration with the outermost
     # electrons removed. Cached, like the two tables it reads, because every ionisation cross section

--- a/pynonthermal/axelrod.py
+++ b/pynonthermal/axelrod.py
@@ -90,6 +90,10 @@ def get_shell_occupancies(atomic_number: int, ion_stage: int) -> npt.NDArray[np.
 
     assert sum(element_shells_q) == nbound
 
+    # the cached array is handed straight to callers, so make a write raise at the mutation site
+    # rather than silently changing the occupancies every later cross section evaluation sees
+    element_shells_q.flags.writeable = False
+
     return element_shells_q
 
 

--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -6,12 +6,24 @@ from pathlib import Path
 import numpy as np
 import numpy.typing as npt
 
+from pynonthermal.constants import CLIGHT
 from pynonthermal.constants import EV
 from pynonthermal.constants import H
 from pynonthermal.constants import ME
 from pynonthermal.constants import QE
 
 DATADIR = Path(__file__).absolute().parent / "data"
+
+
+def get_betasq(en_ev: npt.NDArray[np.float64] | float) -> npt.NDArray[np.float64]:
+    """Get (v/c)^2 for an electron of kinetic energy en_ev [eV], relativistically.
+
+    The classical 2 * en_ev * EV / ME reaches one at 255 keV and is already 5 per cent high at 16 keV,
+    which is within the range of emax_ev this package is used over.
+    """
+    gamma = np.asarray(en_ev, dtype=np.float64) * EV / (ME * CLIGHT**2) + 1.0
+
+    return 1.0 - 1.0 / gamma**2
 
 
 def electronlossfunction(energy_ev: float, n_e_cgs: float) -> float:
@@ -79,21 +91,23 @@ def get_Zbar(ions: Sequence[tuple[int, int]], ionpopdict: dict[tuple[int, int], 
     return Zbar
 
 
-def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
-    # find energy bin lower boundary is less than or equal to search value
-    # assert en_ev >= engrid[0]
-    deltaen = engrid[1] - engrid[0]
-    # assert en_ev < (engrid[-1] + deltaen)
+def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None = None) -> int:
+    # find energy bin lower boundary is less than or equal to search value.
+    # deltaen is the grid spacing, which callers that already hold it should pass in: re-deriving it
+    # from the array costs more than the index arithmetic itself when called in a loop.
+    if deltaen is None:
+        deltaen = float(engrid[1]) - float(engrid[0])
 
-    index = math.floor((en_ev - engrid[0]) / deltaen)
+    index = math.floor((en_ev - float(engrid[0])) / deltaen)
 
     return 0 if index < 0 else min(index, len(engrid) - 1)
 
 
-def get_energyindex_gteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
+def get_energyindex_gteq(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None = None) -> int:
     # find energy bin lower boundary is greater than or equal to search value
-    deltaen = engrid[1] - engrid[0]
+    if deltaen is None:
+        deltaen = float(engrid[1]) - float(engrid[0])
 
-    index = math.ceil((en_ev - engrid[0]) / deltaen)
+    index = math.ceil((en_ev - float(engrid[0])) / deltaen)
 
     return 0 if index < 0 else min(index, len(engrid) - 1)

--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -28,12 +28,22 @@ def electronlossfunction(energy_ev: float, n_e_cgs: float) -> float:
     n_e = n_e_cgs
     energy = energy_ev * EV  # convert eV to erg
 
-    # omegap = math.sqrt(4 * math.pi * n_e_cgs * pow(QE, 2) / ME)
-    omegap = 5.64e4 * math.sqrt(n_e_cgs)
+    omegap = math.sqrt(4 * math.pi * n_e_cgs * QE**2 / ME)
     zetae = H * omegap / 2 / math.pi
 
+    # Kozma & Fransson (1992) give separate Coulomb logarithms above and below 14 eV and the two do not
+    # meet there: the branch below is lower by ln(hbar * v / (exp(eulergamma) * QE^2)), which is a step of
+    # about 2-3 per cent in the loss rate for the free electron densities of interest. The step is part of
+    # the published prescription (and of the ARTIS implementation this follows), so it is left in place
+    # rather than smoothed with a formula that is nobody's.
     if energy_ev > 14:
-        assert 2 * energy > zetae
+        if 2 * energy <= zetae:
+            # the Coulomb logarithm would be zero or negative, giving a non-positive loss rate
+            msg = (
+                f"the free-electron loss function is not valid at {energy_ev} eV for n_e = {n_e_cgs} cm^-3:"
+                f" the plasma energy hbar*omega_p is {zetae / EV:.3g} eV, which is not below 2E."
+            )
+            raise ValueError(msg)
         lossfunc = n_e * 2 * math.pi * QE**4 / energy * math.log(2 * energy / zetae)
     else:
         v = math.sqrt(2 * energy / ME)  # velocity in cm/s (energy is in erg and ME in g, so cgs)

--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -49,23 +49,27 @@ def electronlossfunction(energy_ev: float, n_e_cgs: float) -> float:
     # the published prescription (and of the ARTIS implementation this follows), so it is left in place
     # rather than smoothed with a formula that is nobody's.
     if energy_ev > 14:
-        if 2 * energy <= zetae:
-            # the Coulomb logarithm would be zero or negative, giving a non-positive loss rate
-            msg = (
-                f"the free-electron loss function is not valid at {energy_ev} eV for n_e = {n_e_cgs} cm^-3:"
-                f" the plasma energy hbar*omega_p is {zetae / EV:.3g} eV, which is not below 2E."
-            )
-            raise ValueError(msg)
-        lossfunc = n_e * 2 * math.pi * QE**4 / energy * math.log(2 * energy / zetae)
+        coulomblog_arg = 2 * energy / zetae
     else:
         v = math.sqrt(2 * energy / ME)  # velocity in cm/s (energy is in erg and ME in g, so cgs)
         # Kozma & Fransson (1992) eq. 2 describes the gamma in this Coulomb logarithm as "Euler's
         # constant (Schunk & Hays 1971)", but Schunk & Hays (1971, p. 114) define it by "ln gamma is
         # Euler's constant", i.e. gamma = exp(0.5772) = 1.781 rather than 0.5772 itself.
         exp_eulergamma = math.exp(np.euler_gamma)
-        lossfunc = (
-            n_e * 2 * math.pi * QE**4 / energy * math.log(ME * pow(v, 3) / (exp_eulergamma * pow(QE, 2) * omegap))
+        coulomblog_arg = ME * pow(v, 3) / (exp_eulergamma * pow(QE, 2) * omegap)
+
+    # Both branches lose their meaning once the plasma is dense enough that the Coulomb logarithm
+    # reaches zero, which would put a non-positive loss rate on the Spencer-Fano matrix diagonal. The
+    # low-energy branch fails first, at n_e ~ 7e19 for a 1 eV electron against ~6e23 for the other.
+    if coulomblog_arg <= 1.0:
+        msg = (
+            f"the free-electron loss function is not valid at {energy_ev} eV for n_e = {n_e_cgs} cm^-3:"
+            f" the plasma energy hbar*omega_p is {zetae / EV:.3g} eV, which is too close to the electron"
+            " energy for the Coulomb logarithm to be positive."
         )
+        raise ValueError(msg)
+
+    lossfunc = n_e * 2 * math.pi * QE**4 / energy * math.log(coulomblog_arg)
 
     # lossfunc is now [erg / cm]
     return lossfunc / EV  # return as [eV / cm]
@@ -91,25 +95,19 @@ def get_Zbar(ions: Sequence[tuple[int, int]], ionpopdict: dict[tuple[int, int], 
     return Zbar
 
 
-def _get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None, round_up: bool) -> int:
-    # index of the energy bin holding en_ev, clamped into the grid at both ends.
-    # deltaen must be engrid's own uniform spacing; callers that already hold it pass it in, because
-    # re-deriving it from the array costs more than the index arithmetic itself when called in a loop.
-    # A value that does not match engrid gives silently wrong indices, so it is not a free parameter.
-    if deltaen is None:
-        deltaen = float(engrid[1]) - float(engrid[0])
-
-    offset = (en_ev - float(engrid[0])) / deltaen
+def _get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], round_up: bool) -> int:
+    # index of the energy bin holding en_ev, clamped into the grid at both ends
+    offset = (en_ev - float(engrid[0])) / (float(engrid[1]) - float(engrid[0]))
     index = math.ceil(offset) if round_up else math.floor(offset)
 
     return 0 if index < 0 else min(index, len(engrid) - 1)
 
 
-def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None = None) -> int:
+def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
     """Get the index of the energy bin whose lower boundary is less than or equal to en_ev."""
-    return _get_energyindex(en_ev, engrid, deltaen, round_up=False)
+    return _get_energyindex(en_ev, engrid, round_up=False)
 
 
-def get_energyindex_gteq(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None = None) -> int:
+def get_energyindex_gteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
     """Get the index of the energy bin whose lower boundary is greater than or equal to en_ev."""
-    return _get_energyindex(en_ev, engrid, deltaen, round_up=True)
+    return _get_energyindex(en_ev, engrid, round_up=True)

--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -18,8 +18,8 @@ DATADIR = Path(__file__).absolute().parent / "data"
 def get_betasq(en_ev: npt.NDArray[np.float64] | float) -> npt.NDArray[np.float64]:
     """Get (v/c)^2 for an electron of kinetic energy en_ev [eV], relativistically.
 
-    The classical 2 * en_ev * EV / ME reaches one at 255 keV and is already 5 per cent high at 16 keV,
-    which is within the range of emax_ev this package is used over.
+    The classical 2 * en_ev * EV / (ME * CLIGHT**2) reaches one at 255 keV and is already 5 per cent
+    high at 16 keV, which is within the range of emax_ev this package is used over.
     """
     gamma = np.asarray(en_ev, dtype=np.float64) * EV / (ME * CLIGHT**2) + 1.0
 
@@ -91,23 +91,25 @@ def get_Zbar(ions: Sequence[tuple[int, int]], ionpopdict: dict[tuple[int, int], 
     return Zbar
 
 
-def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None = None) -> int:
-    # find energy bin lower boundary is less than or equal to search value.
-    # deltaen is the grid spacing, which callers that already hold it should pass in: re-deriving it
-    # from the array costs more than the index arithmetic itself when called in a loop.
+def _get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None, round_up: bool) -> int:
+    # index of the energy bin holding en_ev, clamped into the grid at both ends.
+    # deltaen must be engrid's own uniform spacing; callers that already hold it pass it in, because
+    # re-deriving it from the array costs more than the index arithmetic itself when called in a loop.
+    # A value that does not match engrid gives silently wrong indices, so it is not a free parameter.
     if deltaen is None:
         deltaen = float(engrid[1]) - float(engrid[0])
 
-    index = math.floor((en_ev - float(engrid[0])) / deltaen)
+    offset = (en_ev - float(engrid[0])) / deltaen
+    index = math.ceil(offset) if round_up else math.floor(offset)
 
     return 0 if index < 0 else min(index, len(engrid) - 1)
+
+
+def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None = None) -> int:
+    """Get the index of the energy bin whose lower boundary is less than or equal to en_ev."""
+    return _get_energyindex(en_ev, engrid, deltaen, round_up=False)
 
 
 def get_energyindex_gteq(en_ev: float, engrid: npt.NDArray[np.float64], deltaen: float | None = None) -> int:
-    # find energy bin lower boundary is greater than or equal to search value
-    if deltaen is None:
-        deltaen = float(engrid[1]) - float(engrid[0])
-
-    index = math.ceil((en_ev - float(engrid[0])) / deltaen)
-
-    return 0 if index < 0 else min(index, len(engrid) - 1)
+    """Get the index of the energy bin whose lower boundary is greater than or equal to en_ev."""
+    return _get_energyindex(en_ev, engrid, deltaen, round_up=True)

--- a/pynonthermal/collion.py
+++ b/pynonthermal/collion.py
@@ -1,5 +1,4 @@
 from functools import lru_cache
-from math import atan
 from pathlib import Path
 
 import numpy as np
@@ -123,42 +122,45 @@ def read_colliondata(collionfilename: str | Path = "collion.txt") -> pl.DataFram
     )
 
 
+def Psecondary_vec(
+    e_p: npt.NDArray[np.float64] | float, e_s: npt.NDArray[np.float64] | float, ionpot_ev: float, J: float
+) -> npt.NDArray[np.float64]:
+    """Evaluate the secondary-electron energy distribution over arrays of e_p and/or e_s.
+
+    e_p is the primary electron energy [eV] and e_s the secondary electron energy [eV]. The two
+    arguments broadcast against each other, so either may be a scalar. See Psecondary() for the
+    scalar form and the caller's responsibility for the limits of integration.
+    """
+    arr_e_p = np.asarray(e_p, dtype=np.float64)
+    arr_e_s = np.asarray(e_s, dtype=np.float64)
+
+    # below the ionisation threshold there are no secondaries (and the normalisation
+    # atan((e_p - ionpot_ev) / 2 / J) would be zero or negative)
+    norm = np.arctan((arr_e_p - ionpot_ev) / 2.0 / J)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.where(arr_e_p > ionpot_ev, 1.0 / J / norm / (1 + (arr_e_s / J) ** 2), 0.0)
+
+
 def Psecondary(e_p: float, ionpot_ev: float, J: float, e_s: float = -1, epsilon: float = -1) -> float:
     # probability distribution function for secondaries energy e_s [eV] (or equivalently the energy loss of
     # the primary electron epsilon [eV]) given a primary energy e_p [eV] for an impact ionisation event
 
-    assert e_s >= 0 or epsilon >= 0
-
-    if e_p <= ionpot_ev:
-        # below the ionisation threshold there are no secondaries (and the
-        # normalisation atan((e_p - ionpot_ev) / 2 / J) would be zero or negative)
-        return 0.0
+    # the distribution is normalised over the physical support e_s in [0, (e_p - ionpot_ev) / 2] but is
+    # not truncated to it here, so the caller must supply limits of integration that stay inside it
+    if e_s < 0 and epsilon < 0:
+        msg = "either the secondary energy e_s or the primary energy loss epsilon must be given"
+        raise ValueError(msg)
 
     if e_s < 0:
         e_s = epsilon - ionpot_ev
-    if epsilon < 0:
-        epsilon = e_s + ionpot_ev
 
-    #
-    # if epsilon < I:
-    #     return 0.
-    # if e_s < 0:
-    #     return 0.
-    # if e_s > e_p - I:
-    #     return 0.
-    # if e_s > e_p:
-    #     return 0.
-
-    # test case: constant, always below ionisation
-    # Psecondary_e_s_max = 1. / J / 2.
-    # return 1. / Psecondary_e_s_max if (e_s < Psecondary_e_s_max) else 0.
-
-    return 1.0 / J / atan((e_p - ionpot_ev) / 2.0 / J) / (1 + ((e_s / J) ** 2))
+    return float(Psecondary_vec(e_p=e_p, e_s=e_s, ionpot_ev=ionpot_ev, J=J))
 
 
 def get_J(Z: int, ion_stage: int, ionpot_ev: float) -> float:
     # returns an energy in eV
-    # values from Opal et al. 1971 as applied by Kozma & Fransson 1992
+    # values from Opal et al. 1971 as applied by Kozma & Fransson 1992. They are whole-atom measurements
+    # dominated by valence-shell ionisation, but are used for every shell of the ion to match ARTIS.
     if ion_stage == 1:
         if Z == 2:  # He I
             return 15.8

--- a/pynonthermal/collion.py
+++ b/pynonthermal/collion.py
@@ -71,7 +71,6 @@ def read_colliondata(collionfilename: str | Path = "collion.txt") -> pl.DataFram
                 if nbound <= 0:
                     continue
 
-                # ion_shells_q = get_shell_occupancies(Z, ionstage, elements_electron_binding, all_shells_q)
                 try:
                     ion_shells_q = all_shells_q[Z - 1]
                     ionpot = nist_ionisation_energies_ev[(Z, ionstage)] * EV

--- a/pynonthermal/collion.py
+++ b/pynonthermal/collion.py
@@ -128,8 +128,12 @@ def Psecondary_vec(
     """Evaluate the secondary-electron energy distribution over arrays of e_p and/or e_s.
 
     e_p is the primary electron energy [eV] and e_s the secondary electron energy [eV]. The two
-    arguments broadcast against each other, so either may be a scalar. See Psecondary() for the
-    scalar form and the caller's responsibility for the limits of integration.
+    arguments broadcast against each other, so either may be a scalar. Psecondary() is the scalar form.
+
+    The distribution is normalised over its physical support, e_s in [0, (e_p - ionpot_ev) / 2], but is
+    not truncated to it here, so the caller must supply limits of integration that stay inside it. Note
+    also that the normalisation diverges as e_p approaches ionpot_ev from above, so a limit of
+    integration that is snapped onto a coarse energy grid near the threshold can be badly wrong.
     """
     arr_e_p = np.asarray(e_p, dtype=np.float64)
     arr_e_s = np.asarray(e_s, dtype=np.float64)
@@ -145,8 +149,7 @@ def Psecondary(e_p: float, ionpot_ev: float, J: float, e_s: float = -1, epsilon:
     # probability distribution function for secondaries energy e_s [eV] (or equivalently the energy loss of
     # the primary electron epsilon [eV]) given a primary energy e_p [eV] for an impact ionisation event
 
-    # the distribution is normalised over the physical support e_s in [0, (e_p - ionpot_ev) / 2] but is
-    # not truncated to it here, so the caller must supply limits of integration that stay inside it
+    # see Psecondary_vec() for the support that the caller's limits of integration must stay inside
     if e_s < 0 and epsilon < 0:
         msg = "either the secondary energy e_s or the primary energy loss epsilon must be given"
         raise ValueError(msg)

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 import typing as t
 import warnings
-from math import atan
 from pathlib import Path
 
 import artistools as at
@@ -18,7 +17,18 @@ import pynonthermal
 from pynonthermal.axelrod import get_workfn_ev
 from pynonthermal.base import electronlossfunction
 from pynonthermal.base import get_Zbar
+from pynonthermal.constants import CLIGHT
+from pynonthermal.constants import EV
 from pynonthermal.constants import K_B
+from pynonthermal.constants import ME
+
+# number of nodes used to resolve the epsilon integral of Kozma & Fransson equation 6. That integral spans
+# at most emin_ev in energy, which is typically narrower than one cell of the solver's own energy grid, so
+# it needs a sub-grid of its own. The integrand is smooth over such a short interval and needs few nodes.
+NPTS_EPSILON_SUBGRID = 64
+
+# number of nodes used for the integral over E in [0, E_0] of Kozma & Fransson equation 8
+NPTS_SUB_E0_INTEGRAL = 33
 
 SUBSHELLNAMES = [
     "K ",
@@ -251,6 +261,25 @@ class SpencerFanoSolver:
             msg = f"xs_vec has {len(xs_vec)} points but engrid has {len(self.engrid)}"
             raise ValueError(msg)
 
+        # a non-positive transition energy would put matrix entries below the diagonal, where the
+        # triangular solve silently discards them, and a negative population or cross section would
+        # produce a negative excitation fraction that no later check looks for
+        if epsilon_trans_ev <= 0.0:
+            msg = f"epsilon_trans_ev must be greater than zero but is {epsilon_trans_ev}"
+            raise ValueError(msg)
+        if epsilon_trans_ev > self.engrid[-1]:
+            msg = (
+                f"epsilon_trans_ev ({epsilon_trans_ev} eV) is above the top of the energy grid"
+                f" ({self.engrid[-1]} eV), so no electron the solver represents can drive the transition"
+            )
+            raise ValueError(msg)
+        if levelnumberdensity < 0.0:
+            msg = f"levelnumberdensity must be non-negative but is {levelnumberdensity}"
+            raise ValueError(msg)
+        if (xs_vec < 0.0).any():
+            msg = f"xs_vec must be non-negative but its lowest value is {xs_vec.min()}"
+            raise ValueError(msg)
+
         if (Z, ion_stage) not in self.excitationlists:
             self.excitationlists[(Z, ion_stage)] = {}
 
@@ -298,6 +327,15 @@ class SpencerFanoSolver:
         maxnlevelslower: int | None = 5,
         maxnlevelsupper: int | None = 250,
     ) -> None:
+        """Add bound-bound excitations of one ion, with LTE level populations at the given temperature.
+
+        Transitions whose energy lies outside the solver's energy grid are dropped: above emax_ev no
+        electron the solver represents can drive them, and below emin_ev Kozma & Fransson 1992 take every
+        electron to have thermalised already, so their energy is accounted for as heating instead. Unlike
+        the equivalent case in add_ionisation(), this cannot be raised as an error, because real ions have
+        fine-structure transitions far below any usable emin_ev. Pass verbose=True to the solver to see how
+        many transitions were dropped.
+        """
         self._require_not_solved("add excitation")
         if adata_polars is not None:
             self.adata_polars = adata_polars
@@ -339,9 +377,22 @@ class SpencerFanoSolver:
         if maxnlevelsupper is not None:
             lzdftransitions = lzdftransitions.filter(pl.col("upper") < maxnlevelsupper)
 
-        # transitions outside the grid can't be driven by any electron the solver represents
-        lzdftransitions = lzdftransitions.filter(pl.col("epsilon_trans_ev").is_between(self.engrid[0], self.engrid[-1]))
-        dftransitions = lzdftransitions.collect()
+        # transitions outside the grid are dropped (see the docstring), but say how many, so that a grid
+        # that happens to exclude most of an ion's excitation channels doesn't go unnoticed
+        dftransitions_allenergies = lzdftransitions.collect()
+        arr_epsilon_trans_ev = dftransitions_allenergies["epsilon_trans_ev"]
+        n_below_grid = int((arr_epsilon_trans_ev < self.engrid[0]).sum())
+        n_above_grid = int((arr_epsilon_trans_ev > self.engrid[-1]).sum())
+        dftransitions = dftransitions_allenergies.filter(
+            arr_epsilon_trans_ev.is_between(self.engrid[0], self.engrid[-1])
+        )
+
+        if self.verbose and (n_below_grid or n_above_grid):
+            print(
+                f"  dropped {n_below_grid} transition(s) below emin_ev={self.engrid[0]} eV and"
+                f" {n_above_grid} above emax_ev={self.engrid[-1]} eV for Z={Z} ion_stage {ion_stage}"
+                f" ({len(dftransitions)} kept)"
+            )
 
         if not dftransitions.is_empty():
             dftransitions = dftransitions.join(
@@ -432,7 +483,7 @@ class SpencerFanoSolver:
                 # epsilon_lower = en + ionpot_ev
                 # epsilon_upper = min((endash + ionpot_ev) / 2, endash)]
                 epsilon_lower2 = en + ionpot_ev
-                int_eps_lower2 = atan((epsilon_lower2 - ionpot_ev) / J)
+                int_eps_lower2 = math.atan((epsilon_lower2 - ionpot_ev) / J)
                 self.sfmatrix[i, secondintegralstartindex:] -= np.where(
                     epsilon_lower2 <= epsilon_uppers[secondintegralstartindex:],
                     prefactors[secondintegralstartindex:]
@@ -512,6 +563,13 @@ class SpencerFanoSolver:
         self._solved = False
         self.reset_solution_analysis()
 
+        # every fraction and rate coefficient is divided by the deposition rate density. A zero gave a bare
+        # ZeroDivisionError from inside the analysis, and a negative one silently flipped the sign of yvec
+        # and of every rate coefficient while leaving the energy fractions summing to one.
+        if depositionratedensity_ev <= 0.0:
+            msg = f"depositionratedensity_ev must be greater than zero but is {depositionratedensity_ev}"
+            raise ValueError(msg)
+
         self.depositionratedensity_ev = depositionratedensity_ev
         if override_n_e is not None and override_n_e <= 0.0:
             msg = f"override_n_e must be greater than zero but is {override_n_e}"
@@ -585,14 +643,15 @@ class SpencerFanoSolver:
 
         N_e = 0.0
 
-        deltaen = self.engrid[1] - self.engrid[0]
-
         for Z, ion_stage in self._get_all_ions():
             N_e_ion = 0.0
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
 
             for levelnumberdensity, xsvec, epsilon_trans_ev in self.excitationlists.get((Z, ion_stage), {}).values():
-                if energy_ev + epsilon_trans_ev >= self.engrid[0]:
+                # y is only solved for on the grid and is zero above it, so an electron of energy
+                # energy_ev + epsilon_trans_ev only exists while that sum stays inside the grid.
+                # get_energyindex_lteq would otherwise clamp to the last bin and add a spurious term.
+                if self.engrid[0] <= energy_ev + epsilon_trans_ev <= self.engrid[-1]:
                     i = self.get_energyindex_lteq(en_ev=energy_ev + epsilon_trans_ev)
                     # the level population is absolute, so this term is not scaled by n_ion below
                     N_e += levelnumberdensity * self.yvec[i] * xsvec[i]
@@ -608,36 +667,48 @@ class SpencerFanoSolver:
 
                 ar_xs_array = self._get_shell_xs(shell)
 
-                # integral from ionpot to enlambda
-                integral1startindex = self.get_energyindex_lteq(en_ev=ionpot_ev)
-                integral2stopindex = self.get_energyindex_lteq(en_ev=enlambda)
-
-                for j in range(integral1startindex, integral2stopindex + 1):
-                    endash = self.engrid[j]
-                    k = self.get_energyindex_lteq(en_ev=energy_ev + endash)
-                    N_e_ion += (
-                        deltaen
-                        * self.yvec[k]
-                        * ar_xs_array[k]
-                        * pynonthermal.collion.Psecondary(e_p=self.engrid[k], epsilon=endash, ionpot_ev=ionpot_ev, J=J)
+                # Integral over epsilon from ionpot_ev to enlambda. Its width is at most energy_ev, which
+                # is at most E_0 = emin_ev, so it is usually narrower than one cell of self.engrid and has
+                # to be resolved on a sub-grid of its own. Evaluating it on self.engrid instead gave an
+                # error that swung between missing the domain entirely and overcounting it by an order of
+                # magnitude, depending on where the grid points happened to fall relative to ionpot_ev.
+                if enlambda > ionpot_ev:
+                    arr_epsilon = np.linspace(ionpot_ev, enlambda, num=NPTS_EPSILON_SUBGRID, dtype=np.float64)
+                    arr_e_p = energy_ev + arr_epsilon
+                    # y is interpolated from the solution, but the cross section is evaluated directly,
+                    # since it rises steeply from zero just above the threshold that starts this integral
+                    arr_y = np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)
+                    arr_xs = pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell)
+                    arr_psecondary = pynonthermal.collion.Psecondary_vec(
+                        e_p=arr_e_p, e_s=arr_epsilon - ionpot_ev, ionpot_ev=ionpot_ev, J=J
                     )
+                    N_e_ion += float(np.trapezoid(arr_y * arr_xs * arr_psecondary, arr_epsilon))
 
-                # integral from 2E + I up to E_max (skipped when the domain is empty, since
-                # get_energyindex_lteq would clamp to the last bin and add a spurious term;
-                # same guard as in _add_ionisation_shell)
-                if 2 * energy_ev + ionpot_ev < self.engrid[-1] + deltaen:
-                    integral2startindex = self.get_energyindex_lteq(en_ev=2 * energy_ev + ionpot_ev)
-                    N_e_ion += deltaen * sum(
-                        self.yvec[j]
-                        * ar_xs_array[j]
-                        * pynonthermal.collion.Psecondary(
-                            e_p=self.engrid[j],
-                            epsilon=energy_ev + ionpot_ev,
-                            ionpot_ev=ionpot_ev,
-                            J=J,
+                # Integral from 2E + I up to E_max. This domain is wide enough for self.engrid to
+                # resolve, but its lower limit has to be honoured exactly rather than snapped down onto
+                # the grid point below it: 2E + I is only just above the threshold for the small E this
+                # is called with, and Psecondary diverges as its primary energy approaches ionpot_ev.
+                # An empty domain is skipped rather than integrated backwards.
+                en_lower2 = 2 * energy_ev + ionpot_ev
+                if en_lower2 < self.engrid[-1]:
+                    integral2startindex = self.get_energyindex_gteq(en_ev=en_lower2)
+                    arr_e_p2 = np.concatenate(([en_lower2], self.engrid[integral2startindex:]))
+                    arr_y2 = np.concatenate(
+                        (
+                            [np.interp(en_lower2, self.engrid, self.yvec)],
+                            self.yvec[integral2startindex:],
                         )
-                        for j in range(integral2startindex, len(self.engrid))
                     )
+                    arr_xs2 = np.concatenate(
+                        (
+                            pynonthermal.collion.get_arxs_array_shell(np.array([en_lower2]), shell),
+                            ar_xs_array[integral2startindex:],
+                        )
+                    )
+                    arr_psecondary2 = pynonthermal.collion.Psecondary_vec(
+                        e_p=arr_e_p2, e_s=energy_ev, ionpot_ev=ionpot_ev, J=J
+                    )
+                    N_e_ion += float(np.trapezoid(arr_y2 * arr_xs2 * arr_psecondary2, arr_e_p2))
 
             N_e += n_ion * N_e_ion
 
@@ -665,13 +736,13 @@ class SpencerFanoSolver:
         # if self.verbose:
         #     print(f"            frac_heating E_0 * y * l(E_0) part: {frac_heating_E_0_part:.5f}")
 
-        frac_heating_N_e: float = 0.0
-        npts_integral = math.ceil(E_0 / deltaen) * 5
-        # if self.verbose:
-        #     print(f'N_e npts_integral: {npts_integral}')
-        arr_en, deltaen2 = np.linspace(0.0, E_0, num=npts_integral, retstep=True, endpoint=True, dtype=np.float64)
+        # The number of nodes is a property of this integral alone, not of the main energy grid: the
+        # previous ceil(E_0 / deltaen) * 5 came out at 5 nodes for any usual grid, and perversely gave
+        # more nodes as the main grid got coarser. Integrate by trapezoid rather than by summing the
+        # nodes, which counted half a node too much at each end of the interval.
+        arr_en = np.linspace(0.0, E_0, num=NPTS_SUB_E0_INTEGRAL, endpoint=True, dtype=np.float64)
         arr_en_N_e = np.array([en_ev * self.calculate_N_e(en_ev) for en_ev in arr_en], dtype=np.float64)
-        frac_heating_N_e += float(1.0 / self.depositionratedensity_ev * arr_en_N_e.sum() * deltaen2)
+        frac_heating_N_e = float(np.trapezoid(arr_en_N_e, arr_en) / self.depositionratedensity_ev)
 
         if self.verbose:
             print(f" frac_heating(E<EMIN): {frac_heating_N_e:.5f}")
@@ -748,7 +819,7 @@ class SpencerFanoSolver:
                         f" {shell['ionpot_ev']:.2f} eV)"
                     )
 
-                if frac_ionisation_shell > 1:
+                if not 0.0 <= frac_ionisation_shell <= 1.0:
                     warnings.warn(
                         f"invalid frac_ionisation_shell of {frac_ionisation_shell} included in the total",
                         stacklevel=2,
@@ -771,7 +842,7 @@ class SpencerFanoSolver:
 
             frac_excitation_thision = self.calculate_nt_frac_excitation_ion(Z, ion_stage)
 
-            if frac_excitation_thision > 1:
+            if not 0.0 <= frac_excitation_thision <= 1.0:
                 # keep it in the total, as for frac_ionisation_shell, so that the energy conservation
                 # check below still sees the problem instead of a total that silently lost a channel
                 warnings.warn(
@@ -830,14 +901,14 @@ class SpencerFanoSolver:
             )
 
     def get_n_e_nt(self) -> float:
+        """Get the number density of non-thermal electrons in cm^-3."""
         self._require_solved()
-        n_e_nt = 0.0
-        for i, en in enumerate(self.engrid):
-            # oneovervelocity = np.sqrt(9.10938e-31 / 2 / en / 1.60218e-19) / 100.
-            velocity = np.sqrt(2 * en * 1.60218e-19 / 9.10938e-31) * 100.0  # cm/s
-            n_e_nt += self.yvec[i] / velocity * self.deltaen
+        # relativistic speed: the classical sqrt(2E/m_e) is 2.5 per cent too fast at 16 keV, which is
+        # well within the range of emax_ev that this solver is used over
+        gamma = self.engrid * EV / (ME * CLIGHT**2) + 1.0
+        arr_velocity = CLIGHT * np.sqrt(1.0 - 1.0 / gamma**2)  # cm/s
 
-        return n_e_nt
+        return float(np.sum(self.yvec / arr_velocity) * self.deltaen)
 
     def get_frac_heating(self) -> float:
         self._require_solved()
@@ -1010,8 +1081,11 @@ class SpencerFanoSolver:
 
         d_etaheat_by_d_en_vec = self.get_d_etaheating_by_d_en_vec()
 
-        # the plot extends below E_0, where the cross sections are all zero and every remaining
-        # electron thermalises, so only the heating channel is non-zero there
+        # The plot extends below E_0 to show that the ionisation and excitation channels close there:
+        # every threshold is above E_0, so their cross sections are zero and the curves are drawn flat.
+        # The heating curve stops at E_0 instead of continuing, because l(E) * y(E) needs y, which the
+        # solver only has above E_0. The energy that thermalises below E_0 is in get_frac_heating()
+        # (via the integral of E * N_e over [0, E_0]) but has no per-energy curve to draw here.
         engrid_low = np.arange(0.0, E_0, E_0 / 20.0, dtype=float)
         npts_low = len(engrid_low)
         engridfull = np.append(engrid_low, self.engrid)
@@ -1039,7 +1113,9 @@ class SpencerFanoSolver:
             label="Ionisation",
         )
 
-        if self.get_frac_excitation_tot() > 0.0:
+        # test the curve itself rather than get_frac_excitation_tot(), so that drawing a plot does not
+        # trigger analyse_ntspectrum() and its diagnostic warnings as a side effect
+        if d_etaexc_by_d_en_vec.any():
             ax.plot(
                 engridfull,
                 np.append(np.zeros(npts_low), d_etaexc_by_d_en_vec) * engridfull / detaymax,

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -660,9 +660,9 @@ class SpencerFanoSolver:
                 continue
 
             for shell in self._get_ion_collion_rows(Z, ion_stage):
-                ionpot_ev = shell["ionpot_ev"]
+                ionpot_ev = float(shell["ionpot_ev"])
 
-                enlambda = min(self.engrid[-1] - energy_ev, energy_ev + ionpot_ev)
+                enlambda = min(float(self.engrid[-1]) - energy_ev, energy_ev + ionpot_ev)
                 J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
 
                 ar_xs_array = self._get_shell_xs(shell)
@@ -692,10 +692,15 @@ class SpencerFanoSolver:
                 en_lower2 = 2 * energy_ev + ionpot_ev
                 if en_lower2 < self.engrid[-1]:
                     integral2startindex = self.get_energyindex_gteq(en_ev=en_lower2)
-                    arr_e_p2 = np.concatenate(([en_lower2], self.engrid[integral2startindex:]))
+                    arr_e_p2 = np.concatenate(
+                        (
+                            np.array([en_lower2], dtype=np.float64),
+                            self.engrid[integral2startindex:],
+                        )
+                    )
                     arr_y2 = np.concatenate(
                         (
-                            [np.interp(en_lower2, self.engrid, self.yvec)],
+                            np.array([float(np.interp(en_lower2, self.engrid, self.yvec))], dtype=np.float64),
                             self.yvec[integral2startindex:],
                         )
                     )

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -24,14 +24,14 @@ from pynonthermal.constants import K_B
 # number of nodes used to resolve the epsilon integral of Kozma & Fransson equation 6. That integral spans
 # at most emin_ev in energy, which is typically narrower than one cell of the solver's own energy grid, so
 # it needs a sub-grid of its own. The integrand is smooth over such a short interval and needs few nodes.
-NPTS_EPSILON_SUBGRID = 64
+NPTS_EPSILON_SUBGRID: int = 64
 
 # number of nodes used for the integral over E in [0, E_0] of Kozma & Fransson equation 8. This one is
 # not free: every node costs a full calculate_N_e() over all ions and shells, so it dominates the cost
 # of the analysis. Convergence is second order, and the most demanding case found (a large emin_ev,
 # where the sub-E_0 term is a third of the heating) is within 6e-4 of its converged value here, which
 # is far inside the discretisation error of the main grid.
-NPTS_SUB_E0_INTEGRAL = 17
+NPTS_SUB_E0_INTEGRAL: int = 17
 
 SUBSHELLNAMES = [
     "K ",
@@ -636,9 +636,10 @@ class SpencerFanoSolver:
 
         return np.dot(xs_excitation_vec_sum_alltrans, self.yvec) * deltaen / self.depositionratedensity_ev
 
+    @staticmethod
     def _integrate_shell_secondaries(
-        self,
         arr_e_p: npt.NDArray[np.float64],
+        arr_y: npt.NDArray[np.float64],
         arr_xs: npt.NDArray[np.float64],
         e_s: npt.NDArray[np.float64] | float,
         ionpot_ev: float,
@@ -646,9 +647,9 @@ class SpencerFanoSolver:
     ) -> float:
         # The integrand shared by both integrals of Kozma & Fransson equation 6: y(E') sigma(E') P(e_s, E')
         # over the primary energies arr_e_p. Both use E' as the variable of integration, since the first
-        # one's epsilon differs from it only by a constant. y is interpolated from the solution, and is
-        # zero off the grid because the solver has no electrons there.
-        arr_y = np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)
+        # one's epsilon differs from it only by a constant. Each caller supplies y and the cross section
+        # however is cheapest for its own nodes: off the grid they have to be evaluated, but on it the
+        # solution and the cached cross sections can be sliced directly.
         arr_psecondary = pynonthermal.collion.Psecondary_vec(e_p=arr_e_p, e_s=e_s, ionpot_ev=ionpot_ev, J=J)
 
         return float(np.trapezoid(arr_y * arr_xs * arr_psecondary, arr_e_p))
@@ -695,10 +696,13 @@ class SpencerFanoSolver:
                 if enlambda > ionpot_ev:
                     arr_epsilon = np.linspace(ionpot_ev, enlambda, num=NPTS_EPSILON_SUBGRID, dtype=np.float64)
                     arr_e_p = energy_ev + arr_epsilon
-                    # the cross section is evaluated directly off the grid here, since it rises steeply
-                    # from zero just above the threshold that starts this integral
+                    # every node here lies between grid points, so y is interpolated and the cross section
+                    # evaluated directly, the latter because it rises steeply from zero just above the
+                    # ionisation threshold that starts this integral
                     N_e_ion += self._integrate_shell_secondaries(
                         arr_e_p=arr_e_p,
+                        # asarray because np.interp is typed as returning a scalar for a scalar x
+                        arr_y=np.asarray(np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)),
                         arr_xs=pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell),
                         e_s=arr_epsilon - ionpot_ev,
                         ionpot_ev=ionpot_ev,
@@ -714,15 +718,21 @@ class SpencerFanoSolver:
                 if en_lower2 < e_max:
                     startindex = self.get_energyindex_gteq(en_ev=en_lower2)
                     arr_en_lower2 = np.array([en_lower2], dtype=np.float64)
-                    ar_xs_array = self._get_shell_xs(shell)
+                    # every node but the exact lower limit is a grid point, so y and the cross section
+                    # are sliced straight from the solution and the cache. Interpolating the whole tail
+                    # instead would just reproduce those same values at ten times the cost.
                     N_e_ion += self._integrate_shell_secondaries(
                         arr_e_p=np.concatenate((arr_en_lower2, self.engrid[startindex:])),
-                        # the grid part reuses the cached cross sections; only the exact lower limit
-                        # falls between grid points and has to be evaluated
+                        arr_y=np.concatenate(
+                            (
+                                np.interp(arr_en_lower2, self.engrid, self.yvec, left=0.0, right=0.0),
+                                self.yvec[startindex:],
+                            )
+                        ),
                         arr_xs=np.concatenate(
                             (
                                 pynonthermal.collion.get_arxs_array_shell(arr_en_lower2, shell),
-                                ar_xs_array[startindex:],
+                                self._get_shell_xs(shell)[startindex:],
                             )
                         ),
                         e_s=energy_ev,

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
+from scipy import integrate
 from scipy import linalg
 
 import pynonthermal
@@ -21,17 +22,25 @@ from pynonthermal.base import get_Zbar
 from pynonthermal.constants import CLIGHT
 from pynonthermal.constants import K_B
 
-# number of nodes used to resolve the epsilon integral of Kozma & Fransson equation 6. That integral spans
-# at most emin_ev in energy, which is typically narrower than one cell of the solver's own energy grid, so
-# it needs a sub-grid of its own. The integrand is smooth over such a short interval and needs few nodes.
-NPTS_EPSILON_SUBGRID: int = 64
+# Nodes for the sub-grids that resolve the parts of the Kozma & Fransson equation 6 integrals that the
+# solver's own energy grid cannot. Both integrands vary on the scale of J = 0.6 * ionpot_ev, so the node
+# count is set from the domain width in units of J, with a floor for the narrow domains that
+# calculate_frac_heating produces and a cap for the wide ones a direct calculate_N_e call can ask for.
+NPTS_SUBGRID_MIN: int = 65
+NPTS_SUBGRID_MAX: int = 1025
+NPTS_SUBGRID_PER_J: int = 32
 
-# number of nodes used for the integral over E in [0, E_0] of Kozma & Fransson equation 8. This one is
-# not free: every node costs a full calculate_N_e() over all ions and shells, so it dominates the cost
-# of the analysis. Convergence is second order, and the most demanding case found (a large emin_ev,
-# where the sub-E_0 term is a third of the heating) is within 6e-4 of its converged value here, which
-# is far inside the discretisation error of the main grid.
-NPTS_SUB_E0_INTEGRAL: int = 17
+# how many whole grid cells above the lower limit of the second equation 6 integral get the sub-grid
+# treatment. The integrand is steepest at that limit and smooth a few J above it.
+NCELLS_SECOND_INTEGRAL_SUBGRID: int = 2
+
+# Number of nodes for the integral over E in [0, E_0] of Kozma & Fransson equation 8. This one is not
+# free: every node costs a full calculate_N_e() over all ions and shells, so it dominates the cost of
+# the analysis. It is integrated by Simpson's rule, which is fourth order here and reaches an accuracy
+# at 9 nodes that the trapezoid rule needs several hundred for. The node count is a property of this
+# integral alone: the old ceil(E_0 / deltaen) * 5 tied it to the main grid, which gave 5 nodes when
+# emin_ev was below the grid spacing and several hundred when it was well above.
+NPTS_SUB_E0_INTEGRAL: int = 9
 
 SUBSHELLNAMES = [
     "K ",
@@ -184,10 +193,10 @@ class SpencerFanoSolver:
         """Exit the context manager."""
 
     def get_energyindex_lteq(self, en_ev: float) -> int:
-        return pynonthermal.get_energyindex_lteq(en_ev, engrid=self.engrid, deltaen=self.deltaen)
+        return pynonthermal.get_energyindex_lteq(en_ev, engrid=self.engrid)
 
     def get_energyindex_gteq(self, en_ev: float) -> int:
-        return pynonthermal.get_energyindex_gteq(en_ev, engrid=self.engrid, deltaen=self.deltaen)
+        return pynonthermal.get_energyindex_gteq(en_ev, engrid=self.engrid)
 
     def electronlossfunction(self, en_ev: float) -> float:
         return electronlossfunction(en_ev, self.get_n_e())
@@ -276,11 +285,12 @@ class SpencerFanoSolver:
                 f" ({self.engrid[-1]} eV), so no electron the solver represents can drive the transition"
             )
             raise ValueError(msg)
-        if levelnumberdensity < 0.0:
+        # >= rather than < 0, so that NaN, for which every comparison is False, is rejected too
+        if not levelnumberdensity >= 0.0:
             msg = f"levelnumberdensity must be non-negative but is {levelnumberdensity}"
             raise ValueError(msg)
-        if (xs_vec < 0.0).any():
-            msg = f"xs_vec must be non-negative but its lowest value is {xs_vec.min()}"
+        if not (xs_vec >= 0.0).all():
+            msg = f"xs_vec must be non-negative and finite but its lowest value is {xs_vec.min()}"
             raise ValueError(msg)
 
         if (Z, ion_stage) not in self.excitationlists:
@@ -637,6 +647,14 @@ class SpencerFanoSolver:
         return np.dot(xs_excitation_vec_sum_alltrans, self.yvec) * deltaen / self.depositionratedensity_ev
 
     @staticmethod
+    def _npts_subgrid(width_ev: float, J: float) -> int:
+        # nodes for a sub-grid spanning width_ev, given that the integrand varies on the scale of J.
+        # Odd, so that a Simpson-style rule would see whole panels.
+        npts = int(np.clip(NPTS_SUBGRID_PER_J * width_ev / J, NPTS_SUBGRID_MIN, NPTS_SUBGRID_MAX))
+
+        return npts + 1 - npts % 2
+
+    @staticmethod
     def _integrate_shell_secondaries(
         arr_e_p: npt.NDArray[np.float64],
         arr_y: npt.NDArray[np.float64],
@@ -662,22 +680,36 @@ class SpencerFanoSolver:
             return 0.0
 
         N_e = 0.0
-        # as Python floats, since the excitation loop below tests them once per transition
         e_min = float(self.engrid[0])
         e_max = float(self.engrid[-1])
+        deltaen = float(self.deltaen)
+        lastindex = len(self.engrid) - 2
 
         for Z, ion_stage in self._get_all_ions():
             N_e_ion = 0.0
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
 
             for levelnumberdensity, xsvec, epsilon_trans_ev in self.excitationlists.get((Z, ion_stage), {}).values():
-                # y is only solved for on the grid and is zero above it, so an electron of energy
-                # energy_ev + epsilon_trans_ev only exists while that sum stays inside the grid.
-                # get_energyindex_lteq would otherwise clamp to the last bin and add a spurious term.
-                if e_min <= energy_ev + epsilon_trans_ev <= e_max:
-                    i = self.get_energyindex_lteq(en_ev=energy_ev + epsilon_trans_ev)
+                # Interpolate y and the cross section at energy_ev + epsilon_trans_ev, as the two
+                # ionisation integrals below also do, rather than snapping down to the grid point under
+                # it. Snapping lands below the transition energy whenever E has not yet carried the sum
+                # past it, and get_xs_excitation_vector makes the cross section exactly zero there, so
+                # the whole transition silently dropped out: on the helium benchmark at E = 0.25 eV that
+                # was 280 of 296 transitions and 43% of N_e. The interpolation is written out rather
+                # than left to np.interp because this runs once per transition per quadrature node,
+                # where the call overhead of np.interp costs more than the arithmetic; the grid is
+                # uniform, so the index and weight are exact.
+                en_upper = energy_ev + epsilon_trans_ev
+                if e_min <= en_upper <= e_max:
+                    pos = (en_upper - e_min) / deltaen
+                    i = min(int(pos), lastindex)
+                    weight = pos - i
                     # the level population is absolute, so this term is not scaled by n_ion below
-                    N_e += levelnumberdensity * self.yvec[i] * xsvec[i]
+                    N_e += (
+                        levelnumberdensity
+                        * (self.yvec[i] + weight * (self.yvec[i + 1] - self.yvec[i]))
+                        * (xsvec[i] + weight * (xsvec[i + 1] - xsvec[i]))
+                    )
 
             if (Z, ion_stage) not in self._ionisation_ions:
                 continue
@@ -694,7 +726,9 @@ class SpencerFanoSolver:
                 # error that swung between missing the domain entirely and overcounting it by an order of
                 # magnitude, depending on where the grid points happened to fall relative to ionpot_ev.
                 if enlambda > ionpot_ev:
-                    arr_epsilon = np.linspace(ionpot_ev, enlambda, num=NPTS_EPSILON_SUBGRID, dtype=np.float64)
+                    arr_epsilon = np.linspace(
+                        ionpot_ev, enlambda, num=self._npts_subgrid(enlambda - ionpot_ev, J), dtype=np.float64
+                    )
                     arr_e_p = energy_ev + arr_epsilon
                     # every node here lies between grid points, so y is interpolated and the cross section
                     # evaluated directly, the latter because it rises steeply from zero just above the
@@ -709,36 +743,43 @@ class SpencerFanoSolver:
                         J=J,
                     )
 
-                # Integral from 2E + I up to E_max. This domain is wide enough for self.engrid to
-                # resolve, but its lower limit has to be honoured exactly rather than snapped down onto
-                # the grid point below it: 2E + I is only just above the threshold for the small E this
-                # is called with, and Psecondary diverges as its primary energy approaches ionpot_ev.
-                # An empty domain is skipped rather than integrated backwards.
+                # Integral from 2E + I up to E_max. Away from the lower limit self.engrid resolves this
+                # domain, but the Psecondary normalisation 1/atan((E' - I) / 2J) varies on the scale of
+                # J = 0.6 * I rather than deltaen, and 2E + I sits just above the threshold for the small
+                # E this is called with. A single trapezoid panel from 2E + I to the first grid point
+                # above it therefore spans the steepest, most convex part of the integrand and
+                # overestimates it one-sidedly: for Al I on a 1-3000 eV grid at npts=600 that one panel
+                # made the integral 35% high. Resolve the leading panels on a sub-grid, and let the main
+                # grid carry the smooth remainder. An empty domain is skipped rather than integrated
+                # backwards.
                 en_lower2 = 2 * energy_ev + ionpot_ev
                 if en_lower2 < e_max:
                     startindex = self.get_energyindex_gteq(en_ev=en_lower2)
-                    arr_en_lower2 = np.array([en_lower2], dtype=np.float64)
-                    # every node but the exact lower limit is a grid point, so y and the cross section
-                    # are sliced straight from the solution and the cache. Interpolating the whole tail
-                    # instead would just reproduce those same values at ten times the cost.
+                    # cover whole grid cells with the sub-grid, so that it meets the grid part exactly
+                    stopindex = min(startindex + NCELLS_SECOND_INTEGRAL_SUBGRID, len(self.engrid) - 1)
+                    en_upper_low = float(self.engrid[stopindex])
+                    arr_e_p_low = np.linspace(
+                        en_lower2, en_upper_low, num=self._npts_subgrid(en_upper_low - en_lower2, J), dtype=np.float64
+                    )
                     N_e_ion += self._integrate_shell_secondaries(
-                        arr_e_p=np.concatenate((arr_en_lower2, self.engrid[startindex:])),
-                        arr_y=np.concatenate(
-                            (
-                                np.interp(arr_en_lower2, self.engrid, self.yvec, left=0.0, right=0.0),
-                                self.yvec[startindex:],
-                            )
-                        ),
-                        arr_xs=np.concatenate(
-                            (
-                                pynonthermal.collion.get_arxs_array_shell(arr_en_lower2, shell),
-                                self._get_shell_xs(shell)[startindex:],
-                            )
-                        ),
+                        arr_e_p=arr_e_p_low,
+                        arr_y=np.asarray(np.interp(arr_e_p_low, self.engrid, self.yvec, left=0.0, right=0.0)),
+                        arr_xs=pynonthermal.collion.get_arxs_array_shell(arr_e_p_low, shell),
                         e_s=energy_ev,
                         ionpot_ev=ionpot_ev,
                         J=J,
                     )
+                    # the rest is smooth on the scale of J, so y and the cross section come straight
+                    # from the solution and the cache rather than being re-evaluated
+                    if stopindex < len(self.engrid) - 1:
+                        N_e_ion += self._integrate_shell_secondaries(
+                            arr_e_p=self.engrid[stopindex:],
+                            arr_y=self.yvec[stopindex:],
+                            arr_xs=self._get_shell_xs(shell)[stopindex:],
+                            e_s=energy_ev,
+                            ionpot_ev=ionpot_ev,
+                            J=J,
+                        )
 
             N_e += n_ion * N_e_ion
 
@@ -766,13 +807,15 @@ class SpencerFanoSolver:
         # if self.verbose:
         #     print(f"            frac_heating E_0 * y * l(E_0) part: {frac_heating_E_0_part:.5f}")
 
-        # The number of nodes is a property of this integral alone, not of the main energy grid: the
-        # previous ceil(E_0 / deltaen) * 5 came out at 5 nodes for any usual grid, and perversely gave
-        # more nodes as the main grid got coarser. Integrate by trapezoid rather than by summing the
-        # nodes, which counted half a node too much at each end of the interval.
+        # E * N_e(E) is smooth over [0, E_0], so Simpson's rule earns its extra order here: it reaches
+        # 5e-5 of the converged value at 9 nodes where the trapezoid rule needs several hundred, and
+        # every node costs a full calculate_N_e(). Summing the nodes, as the code did before, counted
+        # half a node too much at each end of the interval.
         arr_en = np.linspace(0.0, E_0, num=NPTS_SUB_E0_INTEGRAL, endpoint=True, dtype=np.float64)
         arr_en_N_e = np.array([en_ev * self.calculate_N_e(en_ev) for en_ev in arr_en], dtype=np.float64)
-        frac_heating_N_e = float(np.trapezoid(arr_en_N_e, arr_en) / self.depositionratedensity_ev)
+        # cast because scipy.integrate.simpson is untyped, so its result is Any to the type checkers
+        integral_e_n_e = t.cast("float", integrate.simpson(arr_en_N_e, x=arr_en))
+        frac_heating_N_e = integral_e_n_e / self.depositionratedensity_ev
 
         if self.verbose:
             print(f" frac_heating(E<EMIN): {frac_heating_N_e:.5f}")
@@ -1108,8 +1151,9 @@ class SpencerFanoSolver:
 
         d_etaheat_by_d_en_vec = self.get_d_etaheating_by_d_en_vec()
 
-        # The plot extends below E_0 to show that the ionisation and excitation channels close there:
-        # every threshold is above E_0, so their cross sections are zero and the curves are drawn flat.
+        # The plot extends below E_0 to show where the channels stand there. Every ionisation threshold
+        # is above E_0 (add_ionisation rejects any that are not), so that curve is genuinely zero;
+        # excitation is drawn flat because add_excitation does allow a transition energy below E_0.
         # The heating curve stops at E_0 instead of continuing, because l(E) * y(E) needs y, which the
         # solver only has above E_0. The energy that thermalises below E_0 is in get_frac_heating()
         # (via the integral of E * N_e over [0, E_0]) but has no per-energy curve to draw here.

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -16,19 +16,22 @@ from scipy import linalg
 import pynonthermal
 from pynonthermal.axelrod import get_workfn_ev
 from pynonthermal.base import electronlossfunction
+from pynonthermal.base import get_betasq
 from pynonthermal.base import get_Zbar
 from pynonthermal.constants import CLIGHT
-from pynonthermal.constants import EV
 from pynonthermal.constants import K_B
-from pynonthermal.constants import ME
 
 # number of nodes used to resolve the epsilon integral of Kozma & Fransson equation 6. That integral spans
 # at most emin_ev in energy, which is typically narrower than one cell of the solver's own energy grid, so
 # it needs a sub-grid of its own. The integrand is smooth over such a short interval and needs few nodes.
 NPTS_EPSILON_SUBGRID = 64
 
-# number of nodes used for the integral over E in [0, E_0] of Kozma & Fransson equation 8
-NPTS_SUB_E0_INTEGRAL = 33
+# number of nodes used for the integral over E in [0, E_0] of Kozma & Fransson equation 8. This one is
+# not free: every node costs a full calculate_N_e() over all ions and shells, so it dominates the cost
+# of the analysis. Convergence is second order, and the most demanding case found (a large emin_ev,
+# where the sub-E_0 term is a third of the heating) is within 6e-4 of its converged value here, which
+# is far inside the discretisation error of the main grid.
+NPTS_SUB_E0_INTEGRAL = 17
 
 SUBSHELLNAMES = [
     "K ",
@@ -181,10 +184,10 @@ class SpencerFanoSolver:
         """Exit the context manager."""
 
     def get_energyindex_lteq(self, en_ev: float) -> int:
-        return pynonthermal.get_energyindex_lteq(en_ev, engrid=self.engrid)
+        return pynonthermal.get_energyindex_lteq(en_ev, engrid=self.engrid, deltaen=self.deltaen)
 
     def get_energyindex_gteq(self, en_ev: float) -> int:
-        return pynonthermal.get_energyindex_gteq(en_ev, engrid=self.engrid)
+        return pynonthermal.get_energyindex_gteq(en_ev, engrid=self.engrid, deltaen=self.deltaen)
 
     def electronlossfunction(self, en_ev: float) -> float:
         return electronlossfunction(en_ev, self.get_n_e())
@@ -380,18 +383,17 @@ class SpencerFanoSolver:
         # transitions outside the grid are dropped (see the docstring), but say how many, so that a grid
         # that happens to exclude most of an ion's excitation channels doesn't go unnoticed
         dftransitions_allenergies = lzdftransitions.collect()
-        arr_epsilon_trans_ev = dftransitions_allenergies["epsilon_trans_ev"]
-        n_below_grid = int((arr_epsilon_trans_ev < self.engrid[0]).sum())
-        n_above_grid = int((arr_epsilon_trans_ev > self.engrid[-1]).sum())
         dftransitions = dftransitions_allenergies.filter(
-            arr_epsilon_trans_ev.is_between(self.engrid[0], self.engrid[-1])
+            pl.col("epsilon_trans_ev").is_between(self.engrid[0], self.engrid[-1])
         )
 
-        if self.verbose and (n_below_grid or n_above_grid):
+        if self.verbose and len(dftransitions) < len(dftransitions_allenergies):
+            arr_epsilon_trans_ev = dftransitions_allenergies["epsilon_trans_ev"]
+            n_below_grid = int((arr_epsilon_trans_ev < self.engrid[0]).sum())
             print(
                 f"  dropped {n_below_grid} transition(s) below emin_ev={self.engrid[0]} eV and"
-                f" {n_above_grid} above emax_ev={self.engrid[-1]} eV for Z={Z} ion_stage {ion_stage}"
-                f" ({len(dftransitions)} kept)"
+                f" {len(dftransitions_allenergies) - len(dftransitions) - n_below_grid} above"
+                f" emax_ev={self.engrid[-1]} eV for Z={Z} ion_stage {ion_stage} ({len(dftransitions)} kept)"
             )
 
         if not dftransitions.is_empty():
@@ -620,7 +622,7 @@ class SpencerFanoSolver:
             return 0.0
 
         # integral in Kozma & Fransson equation 9, but summed over all transitions for given ion
-        deltaen = self.engrid[1] - self.engrid[0]
+        deltaen = self.deltaen
         npts = len(self.engrid)
 
         xs_excitation_vec_sum_alltrans = np.zeros(npts)
@@ -634,6 +636,23 @@ class SpencerFanoSolver:
 
         return np.dot(xs_excitation_vec_sum_alltrans, self.yvec) * deltaen / self.depositionratedensity_ev
 
+    def _integrate_shell_secondaries(
+        self,
+        arr_e_p: npt.NDArray[np.float64],
+        arr_xs: npt.NDArray[np.float64],
+        e_s: npt.NDArray[np.float64] | float,
+        ionpot_ev: float,
+        J: float,
+    ) -> float:
+        # The integrand shared by both integrals of Kozma & Fransson equation 6: y(E') sigma(E') P(e_s, E')
+        # over the primary energies arr_e_p. Both use E' as the variable of integration, since the first
+        # one's epsilon differs from it only by a constant. y is interpolated from the solution, and is
+        # zero off the grid because the solver has no electrons there.
+        arr_y = np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)
+        arr_psecondary = pynonthermal.collion.Psecondary_vec(e_p=arr_e_p, e_s=e_s, ionpot_ev=ionpot_ev, J=J)
+
+        return float(np.trapezoid(arr_y * arr_xs * arr_psecondary, arr_e_p))
+
     def calculate_N_e(self, energy_ev: float) -> float:
         # Kozma & Fransson equation 6.
         # Something related to a number of electrons, needed to calculate the heating fraction in equation 3
@@ -642,6 +661,9 @@ class SpencerFanoSolver:
             return 0.0
 
         N_e = 0.0
+        # as Python floats, since the excitation loop below tests them once per transition
+        e_min = float(self.engrid[0])
+        e_max = float(self.engrid[-1])
 
         for Z, ion_stage in self._get_all_ions():
             N_e_ion = 0.0
@@ -651,7 +673,7 @@ class SpencerFanoSolver:
                 # y is only solved for on the grid and is zero above it, so an electron of energy
                 # energy_ev + epsilon_trans_ev only exists while that sum stays inside the grid.
                 # get_energyindex_lteq would otherwise clamp to the last bin and add a spurious term.
-                if self.engrid[0] <= energy_ev + epsilon_trans_ev <= self.engrid[-1]:
+                if e_min <= energy_ev + epsilon_trans_ev <= e_max:
                     i = self.get_energyindex_lteq(en_ev=energy_ev + epsilon_trans_ev)
                     # the level population is absolute, so this term is not scaled by n_ion below
                     N_e += levelnumberdensity * self.yvec[i] * xsvec[i]
@@ -662,10 +684,8 @@ class SpencerFanoSolver:
             for shell in self._get_ion_collion_rows(Z, ion_stage):
                 ionpot_ev = float(shell["ionpot_ev"])
 
-                enlambda = min(float(self.engrid[-1]) - energy_ev, energy_ev + ionpot_ev)
+                enlambda = min(e_max - energy_ev, energy_ev + ionpot_ev)
                 J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
-
-                ar_xs_array = self._get_shell_xs(shell)
 
                 # Integral over epsilon from ionpot_ev to enlambda. Its width is at most energy_ev, which
                 # is at most E_0 = emin_ev, so it is usually narrower than one cell of self.engrid and has
@@ -675,14 +695,15 @@ class SpencerFanoSolver:
                 if enlambda > ionpot_ev:
                     arr_epsilon = np.linspace(ionpot_ev, enlambda, num=NPTS_EPSILON_SUBGRID, dtype=np.float64)
                     arr_e_p = energy_ev + arr_epsilon
-                    # y is interpolated from the solution, but the cross section is evaluated directly,
-                    # since it rises steeply from zero just above the threshold that starts this integral
-                    arr_y = np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)
-                    arr_xs = pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell)
-                    arr_psecondary = pynonthermal.collion.Psecondary_vec(
-                        e_p=arr_e_p, e_s=arr_epsilon - ionpot_ev, ionpot_ev=ionpot_ev, J=J
+                    # the cross section is evaluated directly off the grid here, since it rises steeply
+                    # from zero just above the threshold that starts this integral
+                    N_e_ion += self._integrate_shell_secondaries(
+                        arr_e_p=arr_e_p,
+                        arr_xs=pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell),
+                        e_s=arr_epsilon - ionpot_ev,
+                        ionpot_ev=ionpot_ev,
+                        J=J,
                     )
-                    N_e_ion += float(np.trapezoid(arr_y * arr_xs * arr_psecondary, arr_epsilon))
 
                 # Integral from 2E + I up to E_max. This domain is wide enough for self.engrid to
                 # resolve, but its lower limit has to be honoured exactly rather than snapped down onto
@@ -690,30 +711,24 @@ class SpencerFanoSolver:
                 # is called with, and Psecondary diverges as its primary energy approaches ionpot_ev.
                 # An empty domain is skipped rather than integrated backwards.
                 en_lower2 = 2 * energy_ev + ionpot_ev
-                if en_lower2 < self.engrid[-1]:
-                    integral2startindex = self.get_energyindex_gteq(en_ev=en_lower2)
-                    arr_e_p2 = np.concatenate(
-                        (
-                            np.array([en_lower2], dtype=np.float64),
-                            self.engrid[integral2startindex:],
-                        )
+                if en_lower2 < e_max:
+                    startindex = self.get_energyindex_gteq(en_ev=en_lower2)
+                    arr_en_lower2 = np.array([en_lower2], dtype=np.float64)
+                    ar_xs_array = self._get_shell_xs(shell)
+                    N_e_ion += self._integrate_shell_secondaries(
+                        arr_e_p=np.concatenate((arr_en_lower2, self.engrid[startindex:])),
+                        # the grid part reuses the cached cross sections; only the exact lower limit
+                        # falls between grid points and has to be evaluated
+                        arr_xs=np.concatenate(
+                            (
+                                pynonthermal.collion.get_arxs_array_shell(arr_en_lower2, shell),
+                                ar_xs_array[startindex:],
+                            )
+                        ),
+                        e_s=energy_ev,
+                        ionpot_ev=ionpot_ev,
+                        J=J,
                     )
-                    arr_y2 = np.concatenate(
-                        (
-                            np.array([float(np.interp(en_lower2, self.engrid, self.yvec))], dtype=np.float64),
-                            self.yvec[integral2startindex:],
-                        )
-                    )
-                    arr_xs2 = np.concatenate(
-                        (
-                            pynonthermal.collion.get_arxs_array_shell(np.array([en_lower2]), shell),
-                            ar_xs_array[integral2startindex:],
-                        )
-                    )
-                    arr_psecondary2 = pynonthermal.collion.Psecondary_vec(
-                        e_p=arr_e_p2, e_s=energy_ev, ionpot_ev=ionpot_ev, J=J
-                    )
-                    N_e_ion += float(np.trapezoid(arr_y2 * arr_xs2 * arr_psecondary2, arr_e_p2))
 
             N_e += n_ion * N_e_ion
 
@@ -727,7 +742,7 @@ class SpencerFanoSolver:
         E_0 = self.engrid[0]
         n_e = self.get_n_e()
 
-        deltaen = self.engrid[1] - self.engrid[0]
+        deltaen = self.deltaen
         frac_heating += (
             deltaen
             / self.depositionratedensity_ev
@@ -776,7 +791,7 @@ class SpencerFanoSolver:
         # keep any frac_heating already computed for this solution, since it only depends on yvec
         self._reset_channel_fractions()
 
-        deltaen = self.engrid[1] - self.engrid[0]
+        deltaen = self.deltaen
 
         if self.verbose:
             print(f"    n_e_nt: {self.get_n_e_nt():.2e} [/cm3]")
@@ -908,10 +923,7 @@ class SpencerFanoSolver:
     def get_n_e_nt(self) -> float:
         """Get the number density of non-thermal electrons in cm^-3."""
         self._require_solved()
-        # relativistic speed: the classical sqrt(2E/m_e) is 2.5 per cent too fast at 16 keV, which is
-        # well within the range of emax_ev that this solver is used over
-        gamma = self.engrid * EV / (ME * CLIGHT**2) + 1.0
-        arr_velocity = CLIGHT * np.sqrt(1.0 - 1.0 / gamma**2)  # cm/s
+        arr_velocity = CLIGHT * np.sqrt(get_betasq(self.engrid))  # cm/s
 
         return float(np.sum(self.yvec / arr_velocity) * self.deltaen)
 

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -5,7 +5,9 @@ rather than solver performance, so instrumenting them would only lengthen the Co
 add noise to the tracked benchmark set. Performance-relevant cases live in test_sfsolve.py.
 """
 
+import itertools
 import math
+import warnings
 
 import numpy as np
 import polars as pl
@@ -32,8 +34,10 @@ def test_ionpot_below_emin_rejected() -> None:
     ):
         sf.add_ionisation(26, 1, n_ion=1.0)
 
-    # the same ion is accepted once the cutoff is below its lowest shell, and then conserves energy
-    with pynonthermal.SpencerFanoSolver(emin_ev=7.9, emax_ev=3000, npts=1000) as sf:
+    # the same ion is accepted once the cutoff is below its lowest shell, and then conserves energy.
+    # npts has to resolve the 7.9 and 9.0 eV shells: at npts=1000 the 3 eV grid spacing leaves the
+    # fractions 5.6% short of unity, almost all of it in the ionisation term.
+    with pynonthermal.SpencerFanoSolver(emin_ev=7.9, emax_ev=3000, npts=4000) as sf:
         sf.add_ionisation(26, 1, n_ion=0.99)
         sf.add_ionisation(26, 2, n_ion=0.01)
         sf.solve(depositionratedensity_ev=1e6)
@@ -59,6 +63,74 @@ def test_zero_free_electron_density() -> None:
     # the loss function itself also rejects a non-positive density
     with pytest.raises(ValueError, match="positive free electron density"):
         pynonthermal.electronlossfunction(100.0, 0.0)
+
+
+def test_deposition_rate_validated() -> None:
+    # every fraction and rate coefficient is divided by the deposition rate density. Zero raised a bare
+    # ZeroDivisionError from inside the analysis, and a negative value was accepted outright: it flipped
+    # the sign of yvec and of every rate coefficient while still leaving the fractions summing to one,
+    # so the conservation diagnostic never noticed.
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=300, npts=100) as sf:
+        sf.add_ionisation(8, 2, n_ion=1e8)
+        for badvalue in (0.0, -100.0):
+            with pytest.raises(ValueError, match="depositionratedensity_ev must be greater than zero"):
+                sf.solve(depositionratedensity_ev=badvalue)
+
+        sf.solve(depositionratedensity_ev=1e8)
+        assert (sf.yvec > 0.0).all()
+        assert sf.get_ionisation_ratecoeff(8, 2) > 0.0
+
+
+def test_excitation_inputs_validated() -> None:
+    npts = 100
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=300, npts=npts) as sf:
+        sf.add_ionisation(8, 2, n_ion=1e8)
+        xs_vec = np.full(npts, 1e-16)
+
+        # a non-positive transition energy puts entries below the diagonal, where the triangular
+        # solve silently discards them, and the solution comes out looking plausible
+        for badvalue in (-50.0, 0.0):
+            with pytest.raises(ValueError, match="epsilon_trans_ev must be greater than zero"):
+                sf.add_excitation(8, 2, levelnumberdensity=1e10, xs_vec=xs_vec, epsilon_trans_ev=badvalue)
+
+        # above the top of the grid there is no electron that could drive the transition
+        with pytest.raises(ValueError, match="above the top of the energy grid"):
+            sf.add_excitation(8, 2, levelnumberdensity=1e10, xs_vec=xs_vec, epsilon_trans_ev=301.0)
+
+        # negative populations and cross sections give a negative excitation fraction
+        with pytest.raises(ValueError, match="levelnumberdensity must be non-negative"):
+            sf.add_excitation(8, 2, levelnumberdensity=-1e10, xs_vec=xs_vec, epsilon_trans_ev=20.0)
+        with pytest.raises(ValueError, match="xs_vec must be non-negative"):
+            sf.add_excitation(8, 2, levelnumberdensity=1e10, xs_vec=-xs_vec, epsilon_trans_ev=20.0)
+
+        # a transition exactly at the top of the grid is still legal
+        sf.add_excitation(8, 2, levelnumberdensity=1e10, xs_vec=xs_vec, epsilon_trans_ev=300.0)
+        assert np.array_equal(sf.sfmatrix, np.triu(sf.sfmatrix))
+
+
+def test_N_e_excitation_above_grid() -> None:
+    # eq. 6 evaluates y and the cross section at energy_ev + epsilon_trans_ev. Above the top of the
+    # grid no such electron exists, but get_energyindex_lteq clamps to the last bin, so the term came
+    # out equal to its value at emax_ev instead of zero. This is the same clamp that the second
+    # ionisation integral is already guarded against.
+    npts, emax = 300, 300.0
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=emax, npts=npts) as sf:
+        epsilon_trans_ev = 299.5
+        sf.add_excitation(
+            26,
+            2,
+            levelnumberdensity=1e8,
+            xs_vec=np.where(sf.engrid >= epsilon_trans_ev, 1e-16, 0.0),
+            epsilon_trans_ev=epsilon_trans_ev,
+        )
+        sf.solve(depositionratedensity_ev=1e8, override_n_e=1e8)
+
+        # at 0.5 eV the excited electron is exactly at emax_ev and the term is real
+        assert sf.calculate_N_e(emax - epsilon_trans_ev) > 0.0
+        # above that it would have to have come from an electron the solver never had
+        for energy_ev in (0.75, 1.0):
+            assert energy_ev + epsilon_trans_ev > emax
+            assert sf.calculate_N_e(energy_ev) == 0.0
 
 
 def test_override_n_e_not_confused_with_cache() -> None:
@@ -102,23 +174,59 @@ def test_N_e_empty_second_integral_domain() -> None:
         )
         ionpot_ev = shell["ionpot_ev"]
         J = pynonthermal.collion.get_J(11, 10, ionpot_ev)
-        ar_xs_array = pynonthermal.collion.get_arxs_array_shell(sf.engrid, shell)
 
         energy_ev = 1200.0
         assert 2 * energy_ev + ionpot_ev > sf.engrid[-1] + sf.deltaen  # second domain is empty
 
-        # reference: eq. 6 with only the first integral, endash in [I, min(E_max - E, E + I)]
+        # reference: eq. 6 with only the first integral, epsilon in [I, min(E_max - E, E + I)],
+        # integrated on a grid far finer than the solver's own
         enlambda = min(sf.engrid[-1] - energy_ev, energy_ev + ionpot_ev)
-        expected = 0.0
-        for j in range(sf.get_energyindex_lteq(ionpot_ev), sf.get_energyindex_lteq(enlambda) + 1):
-            endash = float(sf.engrid[j])
-            k = sf.get_energyindex_lteq(energy_ev + endash)
-            p_secondary = pynonthermal.collion.Psecondary(
-                e_p=float(sf.engrid[k]), epsilon=endash, ionpot_ev=ionpot_ev, J=J
-            )
-            expected += 1e8 * sf.deltaen * sf.yvec[k] * ar_xs_array[k] * p_secondary
+        arr_epsilon = np.linspace(ionpot_ev, enlambda, num=20001)
+        arr_e_p = energy_ev + arr_epsilon
+        arr_y = np.interp(arr_e_p, sf.engrid, sf.yvec, left=0.0, right=0.0)
+        arr_xs = pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell)
+        arr_p = np.array(
+            [
+                pynonthermal.collion.Psecondary(e_p=float(e_p), epsilon=float(eps), ionpot_ev=ionpot_ev, J=J)
+                for e_p, eps in zip(arr_e_p, arr_epsilon, strict=True)
+            ]
+        )
+        expected = 1e8 * float(np.trapezoid(arr_y * arr_xs * arr_p, arr_epsilon))
 
-        assert math.isclose(sf.calculate_N_e(energy_ev), expected, rel_tol=1e-12)
+        # the tolerance covers the solver's own coarser sub-grid for this integral, not the second
+        # domain, whose contribution would be several per cent were it not correctly skipped
+        assert math.isclose(sf.calculate_N_e(energy_ev), expected, rel_tol=1e-3)
+
+
+def test_N_e_epsilon_integral_not_keyed_to_the_grid() -> None:
+    # The epsilon integral of eq. 6 spans at most emin_ev, so it is narrower than one cell of a
+    # typical energy grid and needs a sub-grid of its own. Evaluating it on the solver's own grid
+    # instead made the answer depend on where the grid points happened to fall relative to the
+    # ionisation threshold rather than on the resolution. Al I has a 6.0 eV shell, and npts of 600,
+    # 1200, 1800 and 2400 each put a grid point within 10 meV of it on a 1-3000 eV grid, where the
+    # Psecondary normalisation 1/atan((e_p - I) / 2J) diverges. That gave frac_sum of 1.86, 1.37,
+    # 1.15 and 1.07 at those four npts while the next npts up gave 0.99-1.00 each time.
+    fracsums = {}
+    for npts in (600, 700, 1200, 1300, 1800, 1900, 2400, 2500):
+        with (
+            pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=npts) as sf,
+            # the coarsest grids here are genuinely under-resolved, so the conservation diagnostic
+            # fires as designed. This test is about the spikes, not about the residual error.
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("ignore", UserWarning)
+            sf.add_ionisation(13, 1, n_ion=1.0)
+            sf.solve(depositionratedensity_ev=100, override_n_e=1e-4)
+            fracsums[npts] = sf.get_frac_sum()
+
+    for npts_onthreshold, npts_neighbour in ((600, 700), (1200, 1300), (1800, 1900), (2400, 2500)):
+        assert math.isclose(fracsums[npts_onthreshold], fracsums[npts_neighbour], abs_tol=0.03), (
+            f"npts={npts_onthreshold} gives frac_sum={fracsums[npts_onthreshold]} but the neighbouring"
+            f" npts={npts_neighbour} gives {fracsums[npts_neighbour]}"
+        )
+
+    # and the remaining error is ordinary discretisation error, which shrinks with resolution
+    assert abs(fracsums[2500] - 1.0) < abs(fracsums[600] - 1.0)
 
 
 def test_lotz_xs_relativistic() -> None:
@@ -215,3 +323,66 @@ def test_conservation_warning_on_coarse_grid() -> None:
         with pytest.warns(UserWarning, match="energy fractions sum to"):
             frac_sum = sf.get_frac_sum()
         assert not math.isclose(frac_sum, 1.0, rel_tol=0.05)
+
+
+def test_opal_J_applies_to_every_shell_of_its_ion() -> None:
+    # The measured secondary-electron widths of Opal et al. 1971 are whole-atom values dominated by
+    # valence-shell ionisation, but ARTIS applies each to every shell of its ion and pynonthermal
+    # deliberately matches that, so Ne I's 48.5 eV 2s shell gets the same J as its 21.6 eV 2p shell.
+    assert pynonthermal.collion.get_J(2, 1, 24.6) == 15.8  # He I, its only shell
+    for ionpot_ev in (21.6, 48.5):  # Ne I 2p and 2s
+        assert pynonthermal.collion.get_J(10, 1, ionpot_ev) == 24.2
+    for ionpot_ev in (15.8, 29.2):  # Ar I 3p and 3s
+        assert pynonthermal.collion.get_J(18, 1, ionpot_ev) == 10.0
+
+    # every other ion, including the ionised stages of those three, uses the general rule
+    for Z, ion_stage, ionpot_ev in ((26, 2, 16.18), (2, 2, 54.4), (10, 2, 41.0), (18, 2, 27.6)):
+        assert pynonthermal.collion.get_J(Z, ion_stage, ionpot_ev) == 0.6 * ionpot_ev
+
+
+def test_psecondary_requires_an_energy() -> None:
+    # this guard was an assert, so it vanished under python -O and left the sentinel default of -1
+    # to be used as a real secondary energy
+    with pytest.raises(ValueError, match="e_s or the primary energy loss epsilon"):
+        pynonthermal.collion.Psecondary(e_p=100.0, ionpot_ev=10.0, J=6.0)
+
+    # the scalar and vectorised forms have to agree, since the solver uses both
+    e_s = np.array([0.0, 5.0, 20.0])
+    arr = pynonthermal.collion.Psecondary_vec(e_p=100.0, e_s=e_s, ionpot_ev=10.0, J=6.0)
+    for i, value in enumerate(e_s):
+        assert math.isclose(
+            float(arr[i]), pynonthermal.collion.Psecondary(e_p=100.0, e_s=float(value), ionpot_ev=10.0, J=6.0)
+        )
+
+    # below threshold there are no secondaries
+    assert not pynonthermal.collion.Psecondary_vec(e_p=np.array([5.0, 10.0]), e_s=0.0, ionpot_ev=10.0, J=6.0).any()
+
+
+def test_n_e_nt_relativistic() -> None:
+    # the electron speed used to be the classical sqrt(2E/m_e), which exceeds c above 511 keV and is
+    # already 2.5 per cent fast at the 16 keV emax_ev that the iron benchmark uses
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=16000, npts=400) as sf:
+        sf.add_ionisation(26, 2, n_ion=1.0)
+        sf.solve(depositionratedensity_ev=1e8)
+        n_e_nt = sf.get_n_e_nt()
+
+        gamma = sf.engrid * pynonthermal.constants.EV / (pynonthermal.constants.ME * pynonthermal.constants.CLIGHT**2)
+        arr_velocity = pynonthermal.constants.CLIGHT * np.sqrt(1.0 - 1.0 / (gamma + 1.0) ** 2)
+        assert (arr_velocity < pynonthermal.constants.CLIGHT).all()
+        assert math.isclose(n_e_nt, float(np.sum(sf.yvec / arr_velocity) * sf.deltaen))
+
+        # the classical speed is faster, so it gives a lower density
+        arr_velocity_classical = np.sqrt(2 * sf.engrid * pynonthermal.constants.EV / pynonthermal.constants.ME)
+        assert n_e_nt > float(np.sum(sf.yvec / arr_velocity_classical) * sf.deltaen)
+
+
+def test_lossfunction_plasma_energy_guard() -> None:
+    # the high-energy branch is ln(2E / hbar*omega_p), which is zero or negative once the plasma
+    # energy reaches 2E. That was an assert, so under python -O it returned a non-positive loss rate.
+    with pytest.raises(ValueError, match="not valid at"):
+        pynonthermal.electronlossfunction(100.0, 1e30)
+
+    # for densities the solver is actually used at, the loss rate is positive and falls with energy
+    arr_loss = [pynonthermal.electronlossfunction(en_ev, 1e8) for en_ev in (1.0, 5.0, 14.0, 100.0, 3000.0)]
+    assert all(loss > 0.0 for loss in arr_loss)
+    assert all(b < a for a, b in itertools.pairwise(arr_loss))

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -15,6 +15,7 @@ import polars as pl
 import pytest
 
 import pynonthermal
+from pynonthermal import spencerfano
 
 
 def test_grid_validation() -> None:
@@ -225,6 +226,83 @@ def test_N_e_epsilon_integral_not_keyed_to_the_grid() -> None:
 
     # and the remaining error is ordinary discretisation error, which shrinks with resolution
     assert abs(fracsums[2500] - 1.0) < abs(fracsums[600] - 1.0)
+
+
+def test_N_e_epsilon_integral_value_on_a_narrow_domain() -> None:
+    # The checks above pin the symptom (no spikes) rather than the value, so they would still pass if
+    # the epsilon integral returned zero. Pin the value itself, in the regime the fix is for: emin_ev=1
+    # makes the domain [I, E + I] at most 1 eV wide, narrower than the 0.75 eV grid spacing here.
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=4000) as sf:
+        sf.add_ionisation(13, 1, n_ion=1.0)
+        sf.solve(depositionratedensity_ev=100, override_n_e=1e-4)
+
+        shells = (
+            pynonthermal.collion.read_colliondata().filter((pl.col("Z") == 13) & (pl.col("ion_stage") == 1)).to_dicts()
+        )
+        energy_ev = 0.7
+        emax = float(sf.engrid[-1])
+
+        def psecondary(
+            arr_e_p: npt.NDArray[np.float64], e_s: npt.NDArray[np.float64] | float, ionpot_ev: float, J: float
+        ) -> npt.NDArray[np.float64]:
+            # the closed form, so the reference does not depend on the implementation it is checking
+            return 1.0 / J / np.arctan((arr_e_p - ionpot_ev) / 2 / J) / (1 + (np.asarray(e_s) / J) ** 2)
+
+        # both eq. 6 integrals over every shell, each on a grid far finer than the solver's own
+        expected = 0.0
+        narrow_domain_seen = False
+        for shell in shells:
+            ionpot_ev = float(shell["ionpot_ev"])
+            J = pynonthermal.collion.get_J(13, 1, ionpot_ev)
+
+            enlambda = min(emax - energy_ev, energy_ev + ionpot_ev)
+            if enlambda > ionpot_ev:
+                narrow_domain_seen |= (enlambda - ionpot_ev) < sf.deltaen
+                arr_epsilon = np.linspace(ionpot_ev, enlambda, num=20001)
+                arr_e_p = arr_epsilon + energy_ev
+                arr_y = np.interp(arr_e_p, sf.engrid, sf.yvec, left=0.0, right=0.0)
+                arr_xs = pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell)
+                arr_p = psecondary(arr_e_p, arr_epsilon - ionpot_ev, ionpot_ev, J)
+                expected += float(np.trapezoid(arr_y * arr_xs * arr_p, arr_epsilon))
+
+            en_lower2 = 2 * energy_ev + ionpot_ev
+            if en_lower2 < emax:
+                arr_e_p2 = np.linspace(en_lower2, emax, num=40001)
+                arr_y2 = np.interp(arr_e_p2, sf.engrid, sf.yvec, left=0.0, right=0.0)
+                arr_xs2 = pynonthermal.collion.get_arxs_array_shell(arr_e_p2, shell)
+                arr_p2 = psecondary(arr_e_p2, energy_ev, ionpot_ev, J)
+                expected += float(np.trapezoid(arr_y2 * arr_xs2 * arr_p2, arr_e_p2))
+
+        # the epsilon domain really is narrower than one grid cell here, the regime the sub-grid is for
+        assert narrow_domain_seen
+        assert expected > 0.0
+        assert math.isclose(sf.calculate_N_e(energy_ev), expected, rel_tol=0.02)
+
+
+def test_quadrature_resolution_constants_are_adequate() -> None:
+    # NPTS_SUB_E0_INTEGRAL and NPTS_EPSILON_SUBGRID carry accuracy claims in their comments. Pin them,
+    # so that lowering either to buy speed cannot silently degrade frac_heating. emin_ev=7.9 is the
+    # demanding case, where the integral over [0, E_0] is about a third of the heating.
+    def frac_heating(npts_sub_e0: int, npts_epsilon: int) -> float:
+        original = (spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID)
+        spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID = npts_sub_e0, npts_epsilon
+        try:
+            with pynonthermal.SpencerFanoSolver(emin_ev=7.9, emax_ev=3000, npts=2000) as sf:
+                sf.add_ionisation(26, 1, n_ion=0.99)
+                sf.add_ionisation(26, 2, n_ion=0.01)
+                sf.solve(depositionratedensity_ev=1e6)
+                return sf.get_frac_heating()
+        finally:
+            spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID = original
+
+    converged = frac_heating(257, 256)
+    asconfigured = frac_heating(spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID)
+    assert math.isclose(asconfigured, converged, rel_tol=1e-3), (
+        f"the configured resolutions give frac_heating={asconfigured} against a converged {converged}"
+    )
+
+    # and the test would notice a drop: the node count the pre-fix code effectively used is not adequate
+    assert not math.isclose(frac_heating(5, 64), converged, rel_tol=1e-3)
 
 
 def test_lotz_xs_relativistic() -> None:

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -186,12 +186,9 @@ def test_N_e_empty_second_integral_domain() -> None:
         arr_e_p: npt.NDArray[np.float64] = energy_ev + arr_epsilon
         arr_y: npt.NDArray[np.float64] = np.interp(arr_e_p, sf.engrid, sf.yvec, left=0.0, right=0.0)
         arr_xs = pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell)
-        arr_p = np.array(
-            [
-                pynonthermal.collion.Psecondary(e_p=float(e_p), epsilon=float(eps), ionpot_ev=ionpot_ev, J=J)
-                for e_p, eps in zip(arr_e_p, arr_epsilon, strict=True)
-            ]
-        )
+        # the closed form of Psecondary, written out so that the reference does not depend on the
+        # implementation it is checking
+        arr_p = 1.0 / J / np.arctan((arr_e_p - ionpot_ev) / 2 / J) / (1 + ((arr_epsilon - ionpot_ev) / J) ** 2)
         expected = 1e8 * float(np.trapezoid(arr_y * arr_xs * arr_p, arr_epsilon))
 
         # the tolerance covers the solver's own coarser sub-grid for this integral, not the second
@@ -366,15 +363,16 @@ def test_n_e_nt_relativistic() -> None:
         sf.add_ionisation(26, 2, n_ion=1.0)
         sf.solve(depositionratedensity_ev=1e8)
         n_e_nt = sf.get_n_e_nt()
+        assert n_e_nt > 0.0
 
-        gamma = sf.engrid * pynonthermal.constants.EV / (pynonthermal.constants.ME * pynonthermal.constants.CLIGHT**2)
-        arr_velocity = pynonthermal.constants.CLIGHT * np.sqrt(1.0 - 1.0 / (gamma + 1.0) ** 2)
-        assert (arr_velocity < pynonthermal.constants.CLIGHT).all()
-        assert math.isclose(n_e_nt, float(np.sum(sf.yvec / arr_velocity) * sf.deltaen))
-
-        # the classical speed is faster, so it gives a lower density
+        # the classical speed exceeds the relativistic one, so it gives a lower density. Comparing
+        # against it pins the physics without restating the implementation.
         arr_velocity_classical = np.sqrt(2 * sf.engrid * pynonthermal.constants.EV / pynonthermal.constants.ME)
         assert n_e_nt > float(np.sum(sf.yvec / arr_velocity_classical) * sf.deltaen)
+
+        # and no electron may travel faster than light, which the classical form allows above 511 keV
+        assert (pynonthermal.base.get_betasq(sf.engrid) < 1.0).all()
+        assert n_e_nt > float(np.sum(sf.yvec) * sf.deltaen / pynonthermal.constants.CLIGHT)
 
 
 def test_lossfunction_plasma_energy_guard() -> None:

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -10,6 +10,7 @@ import math
 import warnings
 
 import numpy as np
+import numpy.typing as npt
 import polars as pl
 import pytest
 
@@ -172,7 +173,7 @@ def test_N_e_empty_second_integral_domain() -> None:
             .filter((pl.col("Z") == 11) & (pl.col("ion_stage") == 10))
             .to_dicts()[0]
         )
-        ionpot_ev = shell["ionpot_ev"]
+        ionpot_ev = float(shell["ionpot_ev"])
         J = pynonthermal.collion.get_J(11, 10, ionpot_ev)
 
         energy_ev = 1200.0
@@ -180,10 +181,10 @@ def test_N_e_empty_second_integral_domain() -> None:
 
         # reference: eq. 6 with only the first integral, epsilon in [I, min(E_max - E, E + I)],
         # integrated on a grid far finer than the solver's own
-        enlambda = min(sf.engrid[-1] - energy_ev, energy_ev + ionpot_ev)
-        arr_epsilon = np.linspace(ionpot_ev, enlambda, num=20001)
-        arr_e_p = energy_ev + arr_epsilon
-        arr_y = np.interp(arr_e_p, sf.engrid, sf.yvec, left=0.0, right=0.0)
+        enlambda = min(float(sf.engrid[-1]) - energy_ev, energy_ev + ionpot_ev)
+        arr_epsilon: npt.NDArray[np.float64] = np.linspace(ionpot_ev, enlambda, num=20001)
+        arr_e_p: npt.NDArray[np.float64] = energy_ev + arr_epsilon
+        arr_y: npt.NDArray[np.float64] = np.interp(arr_e_p, sf.engrid, sf.yvec, left=0.0, right=0.0)
         arr_xs = pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell)
         arr_p = np.array(
             [
@@ -206,7 +207,7 @@ def test_N_e_epsilon_integral_not_keyed_to_the_grid() -> None:
     # 1200, 1800 and 2400 each put a grid point within 10 meV of it on a 1-3000 eV grid, where the
     # Psecondary normalisation 1/atan((e_p - I) / 2J) diverges. That gave frac_sum of 1.86, 1.37,
     # 1.15 and 1.07 at those four npts while the next npts up gave 0.99-1.00 each time.
-    fracsums = {}
+    fracsums: dict[int, float] = {}
     for npts in (600, 700, 1200, 1300, 1800, 1900, 2400, 2500):
         with (
             pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=npts) as sf,

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -192,9 +192,23 @@ def test_N_e_empty_second_integral_domain() -> None:
         arr_p = 1.0 / J / np.arctan((arr_e_p - ionpot_ev) / 2 / J) / (1 + ((arr_epsilon - ionpot_ev) / J) ** 2)
         expected = 1e8 * float(np.trapezoid(arr_y * arr_xs * arr_p, arr_epsilon))
 
-        # the tolerance covers the solver's own coarser sub-grid for this integral, not the second
-        # domain, whose contribution would be several per cent were it not correctly skipped
-        assert math.isclose(sf.calculate_N_e(energy_ev), expected, rel_tol=1e-3)
+        # the tolerance covers the solver's own coarser sub-grids for these integrals, and is tight
+        # enough to notice the empty-domain guard going away (asserted just below)
+        got = sf.calculate_N_e(energy_ev)
+        assert math.isclose(got, expected, rel_tol=1e-4)
+
+        # reproduce the term the old clamping added, and check the result would no longer pass
+        clamped_index = sf.get_energyindex_lteq(2 * energy_ev + ionpot_ev)
+        spurious = 1e8 * float(
+            sf.deltaen
+            * sf.yvec[clamped_index]
+            * pynonthermal.collion.get_arxs_array_shell(sf.engrid, shell)[clamped_index]
+            * pynonthermal.collion.Psecondary_vec(
+                e_p=float(sf.engrid[clamped_index]), e_s=energy_ev, ionpot_ev=ionpot_ev, J=J
+            )
+        )
+        assert spurious > 0.0
+        assert not math.isclose(got + spurious, expected, rel_tol=1e-4)
 
 
 def test_N_e_epsilon_integral_not_keyed_to_the_grid() -> None:
@@ -205,8 +219,30 @@ def test_N_e_epsilon_integral_not_keyed_to_the_grid() -> None:
     # 1200, 1800 and 2400 each put a grid point within 10 meV of it on a 1-3000 eV grid, where the
     # Psecondary normalisation 1/atan((e_p - I) / 2J) diverges. That gave frac_sum of 1.86, 1.37,
     # 1.15 and 1.07 at those four npts while the next npts up gave 0.99-1.00 each time.
+    # assert the premise rather than trusting the hard-coded npts: each of the first of these pairs
+    # must put a grid point within a few meV of an Al I threshold, and each second one must not
+    ionpots = [
+        float(row["ionpot_ev"])
+        for row in pynonthermal.collion.read_colliondata()
+        .filter((pl.col("Z") == 13) & (pl.col("ion_stage") == 1))
+        .to_dicts()
+    ]
+
+    def distance_to_threshold(npts: int) -> float:
+        engrid = np.linspace(1.0, 3000.0, num=npts)
+        return min(float(np.abs(engrid - ionpot).min()) for ionpot in ionpots)
+
+    pairs = ((600, 700), (1200, 1300), (1800, 1900), (2400, 2900))
+    for npts_onthreshold, npts_neighbour in pairs:
+        assert distance_to_threshold(npts_onthreshold) < 0.01, (
+            f"npts={npts_onthreshold} is no longer on an Al I threshold; this test needs one that is"
+        )
+        assert distance_to_threshold(npts_neighbour) > 0.05, (
+            f"npts={npts_neighbour} is itself on an Al I threshold, so it is not a clean control"
+        )
+
     fracsums: dict[int, float] = {}
-    for npts in (600, 700, 1200, 1300, 1800, 1900, 2400, 2500):
+    for npts in [npts for pair in pairs for npts in pair]:
         with (
             pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=npts) as sf,
             # the coarsest grids here are genuinely under-resolved, so the conservation diagnostic
@@ -218,14 +254,14 @@ def test_N_e_epsilon_integral_not_keyed_to_the_grid() -> None:
             sf.solve(depositionratedensity_ev=100, override_n_e=1e-4)
             fracsums[npts] = sf.get_frac_sum()
 
-    for npts_onthreshold, npts_neighbour in ((600, 700), (1200, 1300), (1800, 1900), (2400, 2500)):
+    for npts_onthreshold, npts_neighbour in pairs:
         assert math.isclose(fracsums[npts_onthreshold], fracsums[npts_neighbour], abs_tol=0.03), (
             f"npts={npts_onthreshold} gives frac_sum={fracsums[npts_onthreshold]} but the neighbouring"
             f" npts={npts_neighbour} gives {fracsums[npts_neighbour]}"
         )
 
     # and the remaining error is ordinary discretisation error, which shrinks with resolution
-    assert abs(fracsums[2500] - 1.0) < abs(fracsums[600] - 1.0)
+    assert abs(fracsums[2900] - 1.0) < abs(fracsums[600] - 1.0)
 
 
 def test_N_e_epsilon_integral_value_on_a_narrow_domain() -> None:
@@ -283,26 +319,24 @@ def test_quadrature_resolution_constants_are_adequate() -> None:
     # NPTS_SUB_E0_INTEGRAL and NPTS_EPSILON_SUBGRID carry accuracy claims in their comments. Pin them,
     # so that lowering either to buy speed cannot silently degrade frac_heating. emin_ev=7.9 is the
     # demanding case, where the integral over [0, E_0] is about a third of the heating.
-    def frac_heating(npts_sub_e0: int, npts_epsilon: int) -> float:
-        original = (spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID)
-        spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID = npts_sub_e0, npts_epsilon
-        try:
-            with pynonthermal.SpencerFanoSolver(emin_ev=7.9, emax_ev=3000, npts=2000) as sf:
-                sf.add_ionisation(26, 1, n_ion=0.99)
-                sf.add_ionisation(26, 2, n_ion=0.01)
-                sf.solve(depositionratedensity_ev=1e6)
-                return sf.get_frac_heating()
-        finally:
-            spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID = original
+    def frac_heating(monkeypatch: pytest.MonkeyPatch, npts_sub_e0: int, emin_ev: float, Z: int) -> float:
+        monkeypatch.setattr(spencerfano, "NPTS_SUB_E0_INTEGRAL", npts_sub_e0)
+        with pynonthermal.SpencerFanoSolver(emin_ev=emin_ev, emax_ev=3000, npts=2000) as sf:
+            sf.add_ionisation(Z, 1, n_ion=0.99)
+            sf.add_ionisation(Z, 2, n_ion=0.01)
+            sf.solve(depositionratedensity_ev=1e6)
+            return sf.get_frac_heating()
 
-    converged = frac_heating(257, 256)
-    asconfigured = frac_heating(spencerfano.NPTS_SUB_E0_INTEGRAL, spencerfano.NPTS_EPSILON_SUBGRID)
-    assert math.isclose(asconfigured, converged, rel_tol=1e-3), (
-        f"the configured resolutions give frac_heating={asconfigured} against a converged {converged}"
-    )
-
-    # and the test would notice a drop: the node count the pre-fix code effectively used is not adequate
-    assert not math.isclose(frac_heating(5, 64), converged, rel_tol=1e-3)
+    # emin_ev has to cover the large values add_ionisation's own error message steers users towards
+    # ("set emin_ev <= {lowest ionpot} eV"), not just the default grid where this term is negligible
+    for emin_ev, Z in ((7.9, 26), (15.7, 18), (24.5, 2)):
+        with pytest.MonkeyPatch.context() as mp:
+            converged = frac_heating(mp, 129, emin_ev, Z)
+            asconfigured = frac_heating(mp, spencerfano.NPTS_SUB_E0_INTEGRAL, emin_ev, Z)
+        assert math.isclose(asconfigured, converged, rel_tol=1e-3), (
+            f"emin_ev={emin_ev}: the configured resolution gives frac_heating={asconfigured}"
+            f" against a converged {converged}"
+        )
 
 
 def test_lotz_xs_relativistic() -> None:


### PR DESCRIPTION
Found in a full code review of the package.

## The main fix

`calculate_N_e` integrates over epsilon in `[I, min(E_max - E, E + I)]`, a domain at most `E` wide. It is only ever called with `E` in `[0, E_0]`, so that domain is at most `emin_ev` wide — narrower than one cell of a typical energy grid. It was nevertheless being evaluated on `self.engrid`, with both limits snapped down by `get_energyindex_lteq`. For Al I on a 1-3000 eV grid the true domain is 1.00 eV wide, but the code assigned it:

| npts | deltaen | weight assigned to a 1.00 eV domain | sampled at eps = |
|---|---|---|---|
| 400 | 7.516 | 7.52 eV | 1.0 |
| 600 | 5.007 | 10.01 eV | 1.0, 6.01 |
| 1000 | 3.002 | 3.00 eV | 4.0 |
| 2000 | 1.500 | 1.50 eV | 5.5 |
| 4000 | 0.750 | 2.25 eV | 5.5, 6.25, 7.0 |

Most sample points sit *below* the 6 eV ionisation threshold, where `Psecondary` is evaluated with a negative secondary energy.

The error was worst where a grid point landed just above a threshold, because the `Psecondary` normalisation `1/atan((e_p - I) / 2J)` diverges there. `npts` of 600, 1200, 1800 and 2400 each put a grid point within 10 meV of Al I's 6.0 eV shell:

```
npts= 600  frac_sum=1.8624      npts= 700  frac_sum=1.0041
npts=1200  frac_sum=1.3650      npts=1300  frac_sum=0.9912
npts=1800  frac_sum=1.1526      npts=1900  frac_sum=0.9871
npts=2400  frac_sum=1.0730      npts=2500  frac_sum=0.9864
```

Of the 108 neutral ions, 14 failed to conserve energy at `npts=600`, the worst reaching `frac_sum = 2.0015`.

Epsilon now gets a sub-grid of its own. Against a heavily resolved reference computed on an identical `yvec` (Cm I):

| npts | old error | new error |
|---|---|---|
| 600 | +0.716 | +0.016 |
| 1500 | -0.0006 | +0.0002 |
| 4000 | +0.0104 | +0.00004 |
| 10000 | +0.0048 | +0.00001 |

The second eq. 6 integral turned out to have the same defect for a different reason: its lower limit `2E + I` was snapped down onto the grid point below it, which for the small `E` this is called with lands just under the threshold. At `npts=600` that contributed a node with `P = 266` in place of the correct `P = 0.95` at the true limit. It now honours the limit exactly.

**Worth knowing:** the old `frac_sum` of ~1.000 at fine grids was a cancellation of errors — the N_e overestimate was offsetting a genuine first-order deficit in the other terms. That deficit is now visible (`frac_sum` reads ~0.99 rather than ~1.00 at `npts=4000` for low-threshold neutrals) and converges away properly: 0 of 108 neutrals fall outside +-5% at `npts >= 2000`, versus 25 at `npts=600`. I checked whether the other channel integrals should move from rectangle sums to trapezoid, and they should not — trapezoid makes it strictly worse, because the rectangle sum is the quadrature the matrix itself is built with. They are left alone.

## Also fixed

- **Excitation term of eq. 6 clamped at the top of the grid.** It evaluates `y` and the cross section at `energy_ev + epsilon_trans_ev`; above `emax_ev` no such electron exists, but `get_energyindex_lteq` clamps to the last bin, so the term came out equal to its value at `emax_ev` instead of zero. Same clamp the second ionisation integral was already guarded against.
- **Sub-`E_0` heating integral sized from the main grid.** `ceil(E_0 / deltaen) * 5` gave 5 nodes for any usual grid and perversely gave *more* nodes as the main grid got coarser. Now a fixed node count, integrated by trapezoid instead of by summing nodes (which counted half a node too much at each end). Both new constants are converged: 16 -> 1024 and 17 -> 513 nodes moves `frac_heating` by 6e-6 relative.
- **Non-positive `depositionratedensity_ev` accepted.** Zero raised a bare `ZeroDivisionError` from inside the analysis; a negative value flipped the sign of `yvec` and of every rate coefficient while the fractions still summed to one, so the conservation diagnostic never noticed. `override_n_e` was already validated.
- **`add_excitation` inputs unvalidated.** A non-positive `epsilon_trans_ev` put entries below the diagonal, where `solve_triangular(lower=False)` silently discards them — the solve still succeeded and reported `frac_excitation_tot = -24.2`. A negative level population gave `-5.2e23`. The per-ion diagnostics now catch fractions below zero as well as above one.
- **Exact constants and relativistic speeds.** Plasma frequency from the module constants rather than the rounded `5.64e4`; `get_n_e_nt` relativistic, since the classical `sqrt(2E/m_e)` exceeds c above 511 keV and is already 2.5% fast at the 16 keV `emax_ev` of the iron benchmark. The asserts guarding the Coulomb logarithm and the `Psecondary` energy arguments are now errors, since both vanish under `python -O`. Together these shift ionisation and excitation output by ~5e-6 relative and change nothing else.
- **Dropped transitions now reported.** `add_ion_ltepopexcitation` drops transitions outside the grid, unavoidably so below `emin_ev` because real ions have fine-structure transitions far below any usable cutoff. It now says how many under `verbose`, and documents why.
- **`plot_channels` triggered the analysis as a side effect** via `get_frac_excitation_tot()`, so drawing a plot could emit conservation warnings. It now tests the curve itself. Its comment also promised a heating curve below `E_0` that is not drawn.

`get_J` is deliberately left applying the Opal et al. 1971 widths to every shell of its ion, matching ARTIS, with a comment recording that they are whole-atom measurements dominated by valence-shell ionisation.

## Testing

24 tests pass, including under `-W error::UserWarning`; ruff and mypy clean. New regression tests cover each fix above. All 5595 ions with `ion_stage > 1` still solve with finite, non-negative `yvec` and `frac_sum` within 5%.

Two existing tests needed changes. `test_ionpot_below_emin_rejected` went from `npts=1000` to `4000`: at 3 eV spacing that Fe I case is 5.6% short of unity with almost all of it in the ionisation term, and it had been passing on the old cancellation. `test_N_e_empty_second_integral_domain` reimplemented the old scheme in its reference, so it is rewritten against a resolved integral while keeping its original intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
