### PR TITLE
Remove the scipy dependency

### DIFF
--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -77,6 +77,10 @@ def solve_upper_triangular(a: npt.NDArray[np.float64], b: npt.NDArray[np.float64
     n = b.shape[0]
     x = np.zeros(n, dtype=np.float64)
     for i in range(n - 1, -1, -1):
+        # move the known terms of row i's equation to the right-hand side and divide by the
+        # diagonal: a[i, i+1:] @ x[i+1:] is a dot product (@ is numpy matrix multiplication,
+        # which for two 1-D vectors is their inner product) of the row's off-diagonal
+        # coefficients with the already-solved higher-index part of x
         x[i] = (b[i] - a[i, i + 1 :] @ x[i + 1 :]) / a[i, i]
     return x
 

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -11,8 +11,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
-from scipy import integrate
-from scipy import linalg
 
 import pynonthermal
 from pynonthermal.axelrod import get_workfn_ev
@@ -72,6 +70,27 @@ SUBSHELLNAMES = [
     "P4",
     "Q1",
 ]
+
+
+def solve_upper_triangular(a: npt.NDArray[np.float64], b: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Solve a x = b for upper-triangular a by back-substitution."""
+    n = b.shape[0]
+    x = np.zeros(n, dtype=np.float64)
+    for i in range(n - 1, -1, -1):
+        x[i] = (b[i] - a[i, i + 1 :] @ x[i + 1 :]) / a[i, i]
+    return x
+
+
+def integrate_simpson_uniform(y: npt.NDArray[np.float64], x: npt.NDArray[np.float64]) -> float:
+    """Composite Simpson's rule on a uniformly-spaced grid with an odd number of points."""
+    npts = x.shape[0]
+    assert npts >= 3
+    assert npts % 2 == 1
+    weights = np.full(npts, 2.0, dtype=np.float64)
+    weights[1::2] = 4.0
+    weights[0] = weights[-1] = 1.0
+    h = (x[-1] - x[0]) / (npts - 1)
+    return float(h / 3.0 * (weights @ y))
 
 
 class SpencerFanoSolver:
@@ -617,13 +636,12 @@ class SpencerFanoSolver:
         for i in range(npts):
             sfmatrix_with_electronloss[i, i] += electronlossfunction(self.engrid[i], n_e)
 
-        # every process moves electrons to lower energies, so only matrix columns j >= i are
-        # populated and the matrix is upper triangular. Solving by back-substitution
-        # (as in Kozma & Fransson 1992) is much faster than a general LU decomposition.
-        yvec_reference = np.array(
-            linalg.solve_triangular(sfmatrix_with_electronloss, self.rhsvec, lower=False),
-            dtype=np.float64,
-        )
+        # every process moves electrons to lower energies, so y(E) depends only on y at higher
+        # energies (Kozma & Fransson 1992): only matrix columns j >= i are populated and the
+        # matrix is upper triangular. K&F invert it with an unspecified "standard matrix
+        # technique"; back-substitution from the highest energy downward (the scheme K&F credit
+        # to Xu 1989) exploits the triangularity and is much faster than a general LU solve.
+        yvec_reference = solve_upper_triangular(sfmatrix_with_electronloss, self.rhsvec)
         self.yvec = np.array(yvec_reference * self.depositionratedensity_ev / self.E_init_ev, dtype=np.float64)
         self._solved = True
 
@@ -813,8 +831,7 @@ class SpencerFanoSolver:
         # half a node too much at each end of the interval.
         arr_en = np.linspace(0.0, E_0, num=NPTS_SUB_E0_INTEGRAL, endpoint=True, dtype=np.float64)
         arr_en_N_e = np.array([en_ev * self.calculate_N_e(en_ev) for en_ev in arr_en], dtype=np.float64)
-        # cast because scipy.integrate.simpson is untyped, so its result is Any to the type checkers
-        integral_e_n_e = t.cast("float", integrate.simpson(arr_en_N_e, x=arr_en))
+        integral_e_n_e = integrate_simpson_uniform(arr_en_N_e, arr_en)
         frac_heating_N_e = integral_e_n_e / self.depositionratedensity_ev
 
         if self.verbose:

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -74,6 +74,15 @@ SUBSHELLNAMES = [
 
 def solve_upper_triangular(a: npt.NDArray[np.float64], b: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     """Solve a x = b for upper-triangular a by back-substitution."""
+    # scipy.linalg.solve_triangular rejected these by default (check_finite and the LAPACK
+    # singularity flag); without the checks, bad inputs would propagate nan/inf into the
+    # solution silently instead of raising
+    if not np.isfinite(a).all() or not np.isfinite(b).all():
+        msg = "matrix and right-hand side must be finite (no nan or inf entries)"
+        raise ValueError(msg)
+    if np.any(np.diagonal(a) == 0.0):
+        msg = "matrix is singular: zero on the diagonal"
+        raise np.linalg.LinAlgError(msg)
     n = b.shape[0]
     x = np.zeros(n, dtype=np.float64)
     for i in range(n - 1, -1, -1):
@@ -601,13 +610,15 @@ class SpencerFanoSolver:
         # every fraction and rate coefficient is divided by the deposition rate density. A zero gave a bare
         # ZeroDivisionError from inside the analysis, and a negative one silently flipped the sign of yvec
         # and of every rate coefficient while leaving the energy fractions summing to one.
-        if depositionratedensity_ev <= 0.0:
-            msg = f"depositionratedensity_ev must be greater than zero but is {depositionratedensity_ev}"
+        # the chained comparison (not a "<= 0.0" test) also rejects nan, whose comparisons are
+        # always False, and inf, which would scale yvec to inf without ever raising
+        if not 0.0 < depositionratedensity_ev < math.inf:
+            msg = f"depositionratedensity_ev must be greater than zero and finite but is {depositionratedensity_ev}"
             raise ValueError(msg)
 
         self.depositionratedensity_ev = depositionratedensity_ev
-        if override_n_e is not None and override_n_e <= 0.0:
-            msg = f"override_n_e must be greater than zero but is {override_n_e}"
+        if override_n_e is not None and not 0.0 < override_n_e < math.inf:
+            msg = f"override_n_e must be greater than zero and finite but is {override_n_e}"
             raise ValueError(msg)
 
         # None clears any previously-set override, so that n_e is calculated on demand from ion populations

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -83,6 +83,39 @@ def test_deposition_rate_validated() -> None:
         assert sf.get_ionisation_ratecoeff(8, 2) > 0.0
 
 
+def test_solve_inputs_reject_nonfinite() -> None:
+    # nan slipped past the old "<= 0.0" guards because nan comparisons are always False, and inf
+    # passed them outright; either then contaminated the solution without any exception being raised
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=300, npts=100) as sf:
+        sf.add_ionisation(8, 2, n_ion=1e8)
+        for badvalue in (math.nan, math.inf):
+            with pytest.raises(ValueError, match="depositionratedensity_ev must be greater than zero and finite"):
+                sf.solve(depositionratedensity_ev=badvalue)
+            with pytest.raises(ValueError, match="override_n_e must be greater than zero and finite"):
+                sf.solve(depositionratedensity_ev=1e8, override_n_e=badvalue)
+
+
+def test_solve_upper_triangular_guards() -> None:
+    # scipy.linalg.solve_triangular raised on non-finite entries and zero diagonals; the numpy
+    # back-substitution that replaced it must do the same rather than return nan/inf solutions
+    a = np.triu(np.ones((3, 3)))
+    b = np.ones(3)
+    assert np.allclose(spencerfano.solve_upper_triangular(a, b), [0.0, 0.0, 1.0])
+
+    a_nonfinite = a.copy()
+    a_nonfinite[0, 2] = math.nan
+    with pytest.raises(ValueError, match="finite"):
+        spencerfano.solve_upper_triangular(a_nonfinite, b)
+
+    with pytest.raises(ValueError, match="finite"):
+        spencerfano.solve_upper_triangular(a, np.array([1.0, math.inf, 1.0]))
+
+    a_singular = a.copy()
+    a_singular[1, 1] = 0.0
+    with pytest.raises(np.linalg.LinAlgError, match="singular"):
+        spencerfano.solve_upper_triangular(a_singular, b)
+
+
 def test_excitation_inputs_validated() -> None:
     npts = 100
     with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=300, npts=npts) as sf:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "matplotlib-inline>=0.2.1",
     "numpy>=2.4.4",
     "polars>=1.40.1",
-    "scipy>=1.17.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -952,7 +952,6 @@ dependencies = [
     { name = "matplotlib-inline" },
     { name = "numpy" },
     { name = "polars" },
-    { name = "scipy" },
 ]
 
 [package.dev-dependencies]
@@ -977,7 +976,6 @@ requires-dist = [
     { name = "matplotlib-inline", specifier = ">=0.2.1" },
     { name = "numpy", specifier = ">=2.4.4" },
     { name = "polars", specifier = ">=1.40.1" },
-    { name = "scipy", specifier = ">=1.17.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## What changed

Removes scipy from the project dependencies by replacing its two call sites in `spencerfano.py` with small pure-numpy implementations:

- **`scipy.linalg.solve_triangular` → `solve_upper_triangular()`** — row-wise back-substitution over the upper-triangular Spencer-Fano matrix.
- **`scipy.integrate.simpson` → `integrate_simpson_uniform()`** — closed-form composite Simpson weights for the uniform, odd-point-count grid used by the `frac_heating` sub-E_0 integral. This also removes the `t.cast` that worked around scipy's untyped API.

Also corrects the attribution comment in `solve()`: Kozma & Fransson 1992 note the triangular structure (y(E) depends only on y at higher energies) but describe inverting their integral equation with an unspecified "standard matrix technique" — the highest-energy-downward scheme is one they credit to Xu 1989, so the back-substitution choice is this code's optimization rather than K&F's prescription.

## Why

Decouples the package from scipy's API. Note that scipy still ships in the environment transitively via artistools, so this doesn't shrink installs — it only removes the direct dependence.

## Benchmarks / accuracy (Fe II + Fe III matrix, default 4096-point grid)

| | scipy (LAPACK trtrs) | numpy back-substitution |
|---|---|---|
| time per solve | 7.5 ms | 7.5 ms (5.5 ms before the finite-input check was added in review) |
| agreement | — | max relative difference 1.7e-14 |

The raw back-substitution is ~25% faster than trtrs: `trtrs` is column-oriented and strides badly over the large row-major array, while back-substitution does contiguous row dot products (one BLAS dot per row); the restored finite-input check (~2 ms, the same scan scipy's check_finite paid for) brings the totals to parity. Full `sf.solve()` wall time is ~0.018 s, so the solve step is minor either way.

The Simpson replacement matches `scipy.integrate.simpson` to 1–2 ulp (summation order only); scipy's extra machinery is only needed for uneven spacing or even point counts, and `NPTS_SUB_E0_INTEGRAL = 9` is asserted odd.

## Reviewer notes

- All 28 tests pass (two added in review for the non-finite/singular input guards); ruff, ruff format, and ty pass via pre-commit.
- `uv.lock` was re-resolved with `uv remove scipy`; scipy stays in the lock as a transitive dependency of artistools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

