### PR TITLE
Optimize matrix fill operations and add comprehensive regression tests

### DIFF
--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -95,7 +95,7 @@ def get_Zbar(ions: Sequence[tuple[int, int]], ionpopdict: dict[tuple[int, int], 
     return Zbar
 
 
-def _get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], round_up: bool) -> int:
+def get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], round_up: bool) -> int:
     # index of the energy bin holding en_ev, clamped into the grid at both ends
     offset = (en_ev - float(engrid[0])) / (float(engrid[1]) - float(engrid[0]))
     index = math.ceil(offset) if round_up else math.floor(offset)
@@ -105,9 +105,9 @@ def _get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], round_up: bo
 
 def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
     """Get the index of the energy bin whose lower boundary is less than or equal to en_ev."""
-    return _get_energyindex(en_ev, engrid, round_up=False)
+    return get_energyindex(en_ev, engrid, round_up=False)
 
 
 def get_energyindex_gteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
     """Get the index of the energy bin whose lower boundary is greater than or equal to en_ev."""
-    return _get_energyindex(en_ev, engrid, round_up=True)
+    return get_energyindex(en_ev, engrid, round_up=True)

--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -95,7 +95,7 @@ def get_Zbar(ions: Sequence[tuple[int, int]], ionpopdict: dict[tuple[int, int], 
     return Zbar
 
 
-def get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], round_up: bool) -> int:
+def _get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], round_up: bool) -> int:
     # index of the energy bin holding en_ev, clamped into the grid at both ends
     offset = (en_ev - float(engrid[0])) / (float(engrid[1]) - float(engrid[0]))
     index = math.ceil(offset) if round_up else math.floor(offset)
@@ -105,9 +105,9 @@ def get_energyindex(en_ev: float, engrid: npt.NDArray[np.float64], round_up: boo
 
 def get_energyindex_lteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
     """Get the index of the energy bin whose lower boundary is less than or equal to en_ev."""
-    return get_energyindex(en_ev, engrid, round_up=False)
+    return _get_energyindex(en_ev, engrid, round_up=False)
 
 
 def get_energyindex_gteq(en_ev: float, engrid: npt.NDArray[np.float64]) -> int:
     """Get the index of the energy bin whose lower boundary is greater than or equal to en_ev."""
-    return get_energyindex(en_ev, engrid, round_up=True)
+    return _get_energyindex(en_ev, engrid, round_up=True)

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -91,7 +91,9 @@ def solve_upper_triangular(
     if diag_add is not None and not np.isfinite(diag_add).all():
         msg = "diagonal addition must be finite (no nan or inf entries)"
         raise ValueError(msg)
-    diag = np.diagonal(a) if diag_add is None else np.diagonal(a) + diag_add
+    diag = np.diagonal(a)
+    if diag_add is not None:
+        diag = diag + diag_add
     if np.any(diag == 0.0):
         msg = "matrix is singular: zero on the diagonal"
         raise np.linalg.LinAlgError(msg)
@@ -351,7 +353,7 @@ class SpencerFanoSolver:
             xs_vec,
             epsilon_trans_ev,
         )
-        vec_xs_excitation_levelnumberdensity_deltae = levelnumberdensity * self.deltaen * xs_vec
+        vec = levelnumberdensity * self.deltaen * xs_vec  # cross section times level density times bin width
         xsstartindex = self.get_energyindex_lteq(en_ev=epsilon_trans_ev)
         npts = len(self.engrid)
 
@@ -366,34 +368,27 @@ class SpencerFanoSolver:
         # the value written at (i, j) is vec[j], independent of the row: row i covers columns
         # [max(i, xsstartindex), stopindex(i)) at full weight plus a partial final bin at
         # stopindex(i), and on the uniform grid stopindex(i) = min(i + k, npts - 1). The whole
-        # contribution is therefore a constant-width band of one 1D vector, written here as a
-        # single strided-view addition (plus one strided diagonal for the partial bins) instead
-        # of npts row slices. Only the rows truncated by the excitation threshold (i < r0) or by
-        # the top of the grid (i > r1) need the row-by-row fill.
-        vec = vec_xs_excitation_levelnumberdensity_deltae
+        # contribution is therefore a constant-width band of one 1D vector, written below as one
+        # windowed addition (plus one matrix diagonal for the partial bins) instead of npts row
+        # slices. Only the rows truncated by the excitation threshold (i < r0) or clipped at the
+        # top of the grid (i >= bandstop) need the row-by-row fill.
         k = int(stopindices[0])
         if np.array_equal(stopindices, np.minimum(np.arange(npts) + k, npts - 1)):
-            r1 = npts - 1 - k  # last row whose stop index is not clipped at the top of the grid
-            r0 = min(xsstartindex, r1 + 1)  # first row with an untruncated full-weight window
+            bandstop = npts - k  # rows before this have their stop index unclipped at min(i + k, npts - 1) = i + k
+            r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
+            nrows = bandstop - r0
             self._excitation_fill_rows(range(r0), vec, xsstartindex, stopindices, delta_en_actuals)
-            nrows = r1 - r0 + 1
-            itemsize = self.sfmatrix.itemsize
-            rowstride = (npts + 1) * itemsize  # one row down and one column right per band row
-            if nrows > 0:
-                if k > 0:
-                    # every element (r0 + r, r0 + r + d) for d < k is addressed exactly once, so the
-                    # in-place add on the strided view is safe; the vec windows may alias each other
-                    # (they are read-only inputs)
-                    band = np.lib.stride_tricks.as_strided(
-                        self.sfmatrix[r0:, r0:], shape=(nrows, k), strides=(rowstride, itemsize)
-                    )
-                    windows = np.lib.stride_tricks.as_strided(vec[r0:], shape=(nrows, k), strides=(itemsize, itemsize))
-                    band += windows
-                fracdiag = np.lib.stride_tricks.as_strided(
-                    self.sfmatrix[r0:, r0 + k :], shape=(nrows,), strides=(rowstride,)
-                )
-                fracdiag += vec[r0 + k : r1 + k + 1] * delta_en_actuals[r0 : r1 + 1] / self.deltaen
-            self._excitation_fill_rows(range(r1 + 1, npts), vec, xsstartindex, stopindices, delta_en_actuals)
+            # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
+            # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
+            flat = self.sfmatrix.reshape(-1, copy=False)
+            flatstart = r0 * (npts + 1)
+            if k > 0:
+                # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
+                band = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
+                band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
+            fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
+            fracdiag += vec[r0 + k : bandstop + k] * delta_en_actuals[r0:bandstop] / self.deltaen
+            self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, stopindices, delta_en_actuals)
         else:
             # float rounding in the stop indices broke the constant band width; fall back to the
             # row-by-row fill, which makes no assumption about the band structure
@@ -407,8 +402,8 @@ class SpencerFanoSolver:
         stopindices: npt.NDArray[np.int64],
         delta_en_actuals: npt.NDArray[np.float64],
     ) -> None:
-        # row-by-row reference fill for one excitation transition, used for the rows the banded
-        # fast path in add_excitation cannot cover (and by tests as the reference implementation)
+        # row-by-row fill for one excitation transition, used for the rows the banded fast path
+        # in add_excitation cannot cover and as its fallback
         for i in rows:
             stopindex = stopindices[i]
             startindex = max(i, xsstartindex)
@@ -557,22 +552,23 @@ class SpencerFanoSolver:
         epsilon_uppers = np.minimum((self.engrid + ionpot_ev) / 2, self.engrid)
         int_eps_uppers = np.arctan((epsilon_uppers - ionpot_ev) / J)
 
-        # for the resulting arrays, use index j - i corresponding to energy endash - en.
-        # Every entry of this shell's contribution is prefactors[j] * (int_eps_uppers[j] -
-        # int_eps_lowers1[j - i]) minus the separable second-integral term, so the whole
-        # npts x npts contribution is determined by these 1D column and offset vectors.
+        # for the resulting arrays, use index j - i corresponding to energy endash - en, so each
+        # entry depends only on the column j and the offset j - i
         epsilon_lowers1 = np.maximum(self.engrid - self.engrid[0], ionpot_ev)
         int_eps_lowers1 = np.arctan((epsilon_lowers1 - ionpot_ev) / J)
 
         # each integral is non-empty (epsilon_lower <= epsilon_upper) on a contiguous column
-        # range whose boundary can only move right as the row energy increases: epsilon_lowers1
-        # rises with j at the full grid spacing once past its ionpot_ev plateau while
-        # epsilon_uppers rises at half that, so they cross at most once per row, and raising en
-        # relaxes the first condition and tightens the second monotonically. The two forward-only
-        # pointers below evaluate the same comparisons the per-row masks used, but only at the
-        # boundaries, and the slice writes touch only the non-zero range of each row.
-        cut1 = xsstartindex  # end of the first integral's non-empty column range
-        jstart2 = 0  # start of the second integral's non-empty column range
+        # range located below without evaluating per-row masks, so the slice writes touch only
+        # the non-zero part of each row. For the first integral: every written column has
+        # engrid[j] >= ionpot_ev, so the range is non-empty while epsilon_lowers1 sits on its
+        # ionpot_ev plateau, and past the plateau it rises with j at the full grid spacing
+        # against half that for epsilon_uppers, giving at most one non-empty-to-empty switch
+        # per row; raising en only moves that switch right, so a forward-only pointer tracks it
+        # with the same comparisons the mask would make. For the second integral the lower
+        # limit is constant along the row, so the range start is a searchsorted into the
+        # non-decreasing epsilon_uppers.
+        cut1 = 0  # end of the first integral's non-empty column range, clamped to jstart per row
+        top_en_plus_deltaen = self.engrid[-1] + deltaen
         for i, en in enumerate(self.engrid):
             # endash ranges from en to SF_EMAX, but skip over the zero-cross section points
             jstart = max(i, xsstartindex)
@@ -584,12 +580,11 @@ class SpencerFanoSolver:
             cut1 = max(cut1, jstart)
             while cut1 < npts and epsilon_lowers1[cut1 - i] <= epsilon_uppers[cut1]:
                 cut1 += 1
-            if cut1 > jstart:
-                self.sfmatrix[i, jstart:cut1] += prefactors[jstart:cut1] * (
-                    int_eps_uppers[jstart:cut1] - int_eps_lowers1[jstart - i : cut1 - i]
-                )
+            self.sfmatrix[i, jstart:cut1] += prefactors[jstart:cut1] * (
+                int_eps_uppers[jstart:cut1] - int_eps_lowers1[jstart - i : cut1 - i]
+            )
 
-            if 2 * en + ionpot_ev < self.engrid[-1] + deltaen:
+            if 2 * en + ionpot_ev < top_en_plus_deltaen:
                 secondintegralstartindex = self.get_energyindex_lteq(float(2 * en + ionpot_ev))
 
                 # endash ranges from 2 * en + ionpot_ev to SF_EMAX
@@ -598,11 +593,8 @@ class SpencerFanoSolver:
                 # epsilon_upper = min((endash + ionpot_ev) / 2, endash)]
                 epsilon_lower2 = en + ionpot_ev
                 int_eps_lower2 = math.atan((epsilon_lower2 - ionpot_ev) / J)
-                jstart2 = max(jstart2, secondintegralstartindex)
-                while jstart2 < npts and epsilon_lower2 > epsilon_uppers[jstart2]:
-                    jstart2 += 1
-                if jstart2 < npts:
-                    self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
+                jstart2 = max(secondintegralstartindex, int(np.searchsorted(epsilon_uppers, epsilon_lower2)))
+                self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
 
     def add_ionisation(self, Z: int, ion_stage: int, n_ion: float) -> None:
         self._require_not_solved("add ionisation")
@@ -694,7 +686,6 @@ class SpencerFanoSolver:
         self._n_e_override = override_n_e
         self._n_e = None
 
-        npts = len(self.engrid)
         n_e = self.get_n_e()
         if n_e <= 0.0:
             # without free electrons there is no thermal loss channel, so electrons below the lowest
@@ -718,7 +709,7 @@ class SpencerFanoSolver:
 
         # the free-electron loss term is diagonal-only, so it is passed to the solver as a 1D
         # vector rather than copying the whole npts x npts matrix just to modify its diagonal
-        lossvec = np.array([electronlossfunction(self.engrid[i], n_e) for i in range(npts)])
+        lossvec = np.array([electronlossfunction(en_ev, n_e) for en_ev in self.engrid])
 
         # every process moves electrons to lower energies, so y(E) depends only on y at higher
         # energies (Kozma & Fransson 1992): only matrix columns j >= i are populated and the

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -496,26 +496,32 @@ class SpencerFanoSolver:
             # linearly, so each distinct k is written once, with the vectors pre-summed.
             groups: dict[int, tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}
             npts = len(self.engrid)
-            for transition in dftransitions.iter_rows(named=True):
-                xs_vec = pynonthermal.excitation.get_xs_excitation_vector(
-                    self.engrid, transition, use_collstrengths=use_collstrengths
-                )
-                vec, k, frac = self._store_excitation(
-                    Z,
-                    ion_stage,
-                    transition["lower_pop"],
-                    xs_vec,
-                    transition["epsilon_trans_ev"],
-                    transitionkey=(transition["lower"], transition["upper"]),
-                )
-                if k not in groups:
-                    groups[k] = (np.zeros(npts), np.zeros(npts))
-                groupvec, groupfracvec = groups[k]
-                groupvec += vec
-                groupfracvec += vec * frac
-
-            for k, (groupvec, groupfracvec) in sorted(groups.items()):
-                self._add_excitation_band(groupvec, groupfracvec, k)
+            try:
+                for transition in dftransitions.iter_rows(named=True):
+                    xs_vec = pynonthermal.excitation.get_xs_excitation_vector(
+                        self.engrid, transition, use_collstrengths=use_collstrengths
+                    )
+                    vec, k, frac = self._store_excitation(
+                        Z,
+                        ion_stage,
+                        transition["lower_pop"],
+                        xs_vec,
+                        transition["epsilon_trans_ev"],
+                        transitionkey=(transition["lower"], transition["upper"]),
+                    )
+                    if k not in groups:
+                        groups[k] = (np.zeros(npts), np.zeros(npts))
+                    groupvec, groupfracvec = groups[k]
+                    groupvec += vec
+                    groupfracvec += vec * frac
+            finally:
+                # _store_excitation validates before it records, so if a transition raises (for
+                # example a duplicate key in custom atomic data), exactly the transitions already
+                # recorded in excitationlists have accumulated bands. Writing them on the way out
+                # keeps the matrix consistent with the bookkeeping for a caller that catches the
+                # error, matching the old behaviour of adding each transition atomically.
+                for k, (groupvec, groupfracvec) in sorted(groups.items()):
+                    self._add_excitation_band(groupvec, groupfracvec, k)
 
     def _add_ionisation_shell(self, n_ion: float, shell: dict[str, int | float]) -> None:
         # add the terms related to ionisation cross sections for one shell

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -72,15 +72,27 @@ SUBSHELLNAMES = [
 ]
 
 
-def solve_upper_triangular(a: npt.NDArray[np.float64], b: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
-    """Solve a x = b for upper-triangular a by back-substitution."""
+def solve_upper_triangular(
+    a: npt.NDArray[np.float64],
+    b: npt.NDArray[np.float64],
+    diag_add: npt.NDArray[np.float64] | None = None,
+) -> npt.NDArray[np.float64]:
+    """Solve (a + diag(diag_add)) x = b for upper-triangular a by back-substitution.
+
+    diag_add lets a purely diagonal term (like the free-electron loss function) be applied
+    without copying a into a second npts x npts matrix just to modify its diagonal.
+    """
     # scipy.linalg.solve_triangular rejected these by default (check_finite and the LAPACK
     # singularity flag); without the checks, bad inputs would propagate nan/inf into the
     # solution silently instead of raising
     if not np.isfinite(a).all() or not np.isfinite(b).all():
         msg = "matrix and right-hand side must be finite (no nan or inf entries)"
         raise ValueError(msg)
-    if np.any(np.diagonal(a) == 0.0):
+    if diag_add is not None and not np.isfinite(diag_add).all():
+        msg = "diagonal addition must be finite (no nan or inf entries)"
+        raise ValueError(msg)
+    diag = np.diagonal(a) if diag_add is None else np.diagonal(a) + diag_add
+    if np.any(diag == 0.0):
         msg = "matrix is singular: zero on the diagonal"
         raise np.linalg.LinAlgError(msg)
     n = b.shape[0]
@@ -90,7 +102,7 @@ def solve_upper_triangular(a: npt.NDArray[np.float64], b: npt.NDArray[np.float64
         # diagonal: a[i, i+1:] @ x[i+1:] is a dot product (@ is numpy matrix multiplication,
         # which for two 1-D vectors is their inner product) of the row's off-diagonal
         # coefficients with the already-solved higher-index part of x
-        x[i] = (b[i] - a[i, i + 1 :] @ x[i + 1 :]) / a[i, i]
+        x[i] = (b[i] - a[i, i + 1 :] @ x[i + 1 :]) / diag[i]
     return x
 
 
@@ -351,15 +363,59 @@ class SpencerFanoSolver:
         # grid (the excitation integral is truncated at the grid boundary)
         delta_en_actuals = np.minimum(self.engrid + epsilon_trans_ev - self.engrid[stopindices], self.deltaen)
 
-        for i in range(npts):
+        # the value written at (i, j) is vec[j], independent of the row: row i covers columns
+        # [max(i, xsstartindex), stopindex(i)) at full weight plus a partial final bin at
+        # stopindex(i), and on the uniform grid stopindex(i) = min(i + k, npts - 1). The whole
+        # contribution is therefore a constant-width band of one 1D vector, written here as a
+        # single strided-view addition (plus one strided diagonal for the partial bins) instead
+        # of npts row slices. Only the rows truncated by the excitation threshold (i < r0) or by
+        # the top of the grid (i > r1) need the row-by-row fill.
+        vec = vec_xs_excitation_levelnumberdensity_deltae
+        k = int(stopindices[0])
+        if np.array_equal(stopindices, np.minimum(np.arange(npts) + k, npts - 1)):
+            r1 = npts - 1 - k  # last row whose stop index is not clipped at the top of the grid
+            r0 = min(xsstartindex, r1 + 1)  # first row with an untruncated full-weight window
+            self._excitation_fill_rows(range(r0), vec, xsstartindex, stopindices, delta_en_actuals)
+            nrows = r1 - r0 + 1
+            itemsize = self.sfmatrix.itemsize
+            rowstride = (npts + 1) * itemsize  # one row down and one column right per band row
+            if nrows > 0:
+                if k > 0:
+                    # every element (r0 + r, r0 + r + d) for d < k is addressed exactly once, so the
+                    # in-place add on the strided view is safe; the vec windows may alias each other
+                    # (they are read-only inputs)
+                    band = np.lib.stride_tricks.as_strided(
+                        self.sfmatrix[r0:, r0:], shape=(nrows, k), strides=(rowstride, itemsize)
+                    )
+                    windows = np.lib.stride_tricks.as_strided(vec[r0:], shape=(nrows, k), strides=(itemsize, itemsize))
+                    band += windows
+                fracdiag = np.lib.stride_tricks.as_strided(
+                    self.sfmatrix[r0:, r0 + k :], shape=(nrows,), strides=(rowstride,)
+                )
+                fracdiag += vec[r0 + k : r1 + k + 1] * delta_en_actuals[r0 : r1 + 1] / self.deltaen
+            self._excitation_fill_rows(range(r1 + 1, npts), vec, xsstartindex, stopindices, delta_en_actuals)
+        else:
+            # float rounding in the stop indices broke the constant band width; fall back to the
+            # row-by-row fill, which makes no assumption about the band structure
+            self._excitation_fill_rows(range(npts), vec, xsstartindex, stopindices, delta_en_actuals)
+
+    def _excitation_fill_rows(
+        self,
+        rows: range,
+        vec: npt.NDArray[np.float64],
+        xsstartindex: int,
+        stopindices: npt.NDArray[np.int64],
+        delta_en_actuals: npt.NDArray[np.float64],
+    ) -> None:
+        # row-by-row reference fill for one excitation transition, used for the rows the banded
+        # fast path in add_excitation cannot cover (and by tests as the reference implementation)
+        for i in rows:
             stopindex = stopindices[i]
             startindex = max(i, xsstartindex)
-            self.sfmatrix[i, startindex:stopindex] += vec_xs_excitation_levelnumberdensity_deltae[startindex:stopindex]
+            self.sfmatrix[i, startindex:stopindex] += vec[startindex:stopindex]
 
             # do the last bit separately because we're not using the full deltaen interval
-            self.sfmatrix[i, stopindex] += (
-                vec_xs_excitation_levelnumberdensity_deltae[stopindex] * delta_en_actuals[i] / self.deltaen
-            )
+            self.sfmatrix[i, stopindex] += vec[stopindex] * delta_en_actuals[i] / self.deltaen
 
     def add_ion_ltepopexcitation(
         self,
@@ -501,10 +557,22 @@ class SpencerFanoSolver:
         epsilon_uppers = np.minimum((self.engrid + ionpot_ev) / 2, self.engrid)
         int_eps_uppers = np.arctan((epsilon_uppers - ionpot_ev) / J)
 
-        # for the resulting arrays, use index j - i corresponding to energy endash - en
+        # for the resulting arrays, use index j - i corresponding to energy endash - en.
+        # Every entry of this shell's contribution is prefactors[j] * (int_eps_uppers[j] -
+        # int_eps_lowers1[j - i]) minus the separable second-integral term, so the whole
+        # npts x npts contribution is determined by these 1D column and offset vectors.
         epsilon_lowers1 = np.maximum(self.engrid - self.engrid[0], ionpot_ev)
         int_eps_lowers1 = np.arctan((epsilon_lowers1 - ionpot_ev) / J)
 
+        # each integral is non-empty (epsilon_lower <= epsilon_upper) on a contiguous column
+        # range whose boundary can only move right as the row energy increases: epsilon_lowers1
+        # rises with j at the full grid spacing once past its ionpot_ev plateau while
+        # epsilon_uppers rises at half that, so they cross at most once per row, and raising en
+        # relaxes the first condition and tightens the second monotonically. The two forward-only
+        # pointers below evaluate the same comparisons the per-row masks used, but only at the
+        # boundaries, and the slice writes touch only the non-zero range of each row.
+        cut1 = xsstartindex  # end of the first integral's non-empty column range
+        jstart2 = 0  # start of the second integral's non-empty column range
         for i, en in enumerate(self.engrid):
             # endash ranges from en to SF_EMAX, but skip over the zero-cross section points
             jstart = max(i, xsstartindex)
@@ -513,11 +581,13 @@ class SpencerFanoSolver:
             # at each endash (columns j >= jstart), the integral in epsilon ranges from
             # epsilon_lower = max(endash - en, ionpot_ev)
             # epsilon_upper = min((endash + ionpot_ev) / 2, endash)]
-            self.sfmatrix[i, jstart:] += np.where(
-                epsilon_lowers1[jstart - i : npts - i] <= epsilon_uppers[jstart:],
-                prefactors[jstart:] * (int_eps_uppers[jstart:] - int_eps_lowers1[jstart - i : npts - i]),
-                0.0,
-            )
+            cut1 = max(cut1, jstart)
+            while cut1 < npts and epsilon_lowers1[cut1 - i] <= epsilon_uppers[cut1]:
+                cut1 += 1
+            if cut1 > jstart:
+                self.sfmatrix[i, jstart:cut1] += prefactors[jstart:cut1] * (
+                    int_eps_uppers[jstart:cut1] - int_eps_lowers1[jstart - i : cut1 - i]
+                )
 
             if 2 * en + ionpot_ev < self.engrid[-1] + deltaen:
                 secondintegralstartindex = self.get_energyindex_lteq(float(2 * en + ionpot_ev))
@@ -528,12 +598,11 @@ class SpencerFanoSolver:
                 # epsilon_upper = min((endash + ionpot_ev) / 2, endash)]
                 epsilon_lower2 = en + ionpot_ev
                 int_eps_lower2 = math.atan((epsilon_lower2 - ionpot_ev) / J)
-                self.sfmatrix[i, secondintegralstartindex:] -= np.where(
-                    epsilon_lower2 <= epsilon_uppers[secondintegralstartindex:],
-                    prefactors[secondintegralstartindex:]
-                    * (int_eps_uppers[secondintegralstartindex:] - int_eps_lower2),
-                    0.0,
-                )
+                jstart2 = max(jstart2, secondintegralstartindex)
+                while jstart2 < npts and epsilon_lower2 > epsilon_uppers[jstart2]:
+                    jstart2 += 1
+                if jstart2 < npts:
+                    self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
 
     def add_ionisation(self, Z: int, ion_stage: int, n_ion: float) -> None:
         self._require_not_solved("add ionisation")
@@ -647,16 +716,16 @@ class SpencerFanoSolver:
             print(f"       x_e: {x_e:.2e} [/cm3]        (electrons per nucleus)")
             print(f"deposition: {self.depositionratedensity_ev:7.2f}  [eV/s/cm3]")
 
-        sfmatrix_with_electronloss = self.sfmatrix.copy()
-        for i in range(npts):
-            sfmatrix_with_electronloss[i, i] += electronlossfunction(self.engrid[i], n_e)
+        # the free-electron loss term is diagonal-only, so it is passed to the solver as a 1D
+        # vector rather than copying the whole npts x npts matrix just to modify its diagonal
+        lossvec = np.array([electronlossfunction(self.engrid[i], n_e) for i in range(npts)])
 
         # every process moves electrons to lower energies, so y(E) depends only on y at higher
         # energies (Kozma & Fransson 1992): only matrix columns j >= i are populated and the
         # matrix is upper triangular. K&F invert it with an unspecified "standard matrix
         # technique"; back-substitution from the highest energy downward (the scheme K&F credit
         # to Xu 1989) exploits the triangularity and is much faster than a general LU solve.
-        yvec_reference = solve_upper_triangular(sfmatrix_with_electronloss, self.rhsvec)
+        yvec_reference = solve_upper_triangular(self.sfmatrix, self.rhsvec, diag_add=lossvec)
         self.yvec = np.array(yvec_reference * self.depositionratedensity_ev / self.E_init_ev, dtype=np.float64)
         self._solved = True
 

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -40,6 +40,13 @@ NCELLS_SECOND_INTEGRAL_SUBGRID: int = 2
 # emin_ev was below the grid spacing and several hundred when it was well above.
 NPTS_SUB_E0_INTEGRAL: int = 9
 
+# Excitation contributions are summed per band offset in a small cache-resident buffer and
+# applied to the matrix in one pass per offset when the matrix is next read, instead of
+# sweeping a strip of the whole npts x npts matrix once per transition. The buffer covers
+# bands up to this many offsets; the rare wider bands (epsilon_trans_ev of hundreds of eV at
+# the default grid spacing) are written to the matrix directly.
+EXCITATION_BAND_ACCUM_MAX_ROWS: int = 256
+
 SUBSHELLNAMES = [
     "K ",
     "L1",
@@ -152,7 +159,9 @@ class SpencerFanoSolver:
     dfcollion: pl.DataFrame
     rhsvec: npt.NDArray[np.float64]
     E_init_ev: float
-    sfmatrix: npt.NDArray[np.float64]
+    _sfmatrix: npt.NDArray[np.float64]
+    _excitation_band: npt.NDArray[np.float64] | None
+    _excitation_band_nrows: int
     adata_polars: pl.DataFrame | None
     yvec: npt.NDArray[np.float64]
 
@@ -229,7 +238,9 @@ class SpencerFanoSolver:
                 f" {source_emax:.2f} eV with E_init {self.E_init_ev:7.2f} [eV/s/cm3]"
             )
 
-        self.sfmatrix = np.zeros((npts, npts))
+        self._sfmatrix = np.zeros((npts, npts))
+        self._excitation_band = None
+        self._excitation_band_nrows = 0
 
     def __enter__(self) -> t.Self:
         """Enter the context manager."""
@@ -293,6 +304,25 @@ class SpencerFanoSolver:
         if key not in self._shell_xs:
             self._shell_xs[key] = pynonthermal.collion.get_arxs_array_shell(self.engrid, shell)
         return self._shell_xs[key]
+
+    @property
+    def sfmatrix(self) -> npt.NDArray[np.float64]:
+        """The Spencer-Fano matrix, with any pending excitation contributions applied."""
+        self._flush_excitation_band()
+        return self._sfmatrix
+
+    def _flush_excitation_band(self) -> None:
+        # apply the summed per-offset excitation contributions to the matrix: buffer row d
+        # holds the values of the matrix elements (i, i + d), i.e. the d-th superdiagonal
+        band = self._excitation_band
+        if band is None:
+            return
+        self._excitation_band = None
+        npts = len(self.engrid)
+        flat = self._sfmatrix.reshape(-1, copy=False)
+        for d in range(self._excitation_band_nrows):
+            flat[d :: npts + 1][: npts - d] += band[d, d:]
+        self._excitation_band_nrows = 0
 
     def add_excitation(
         self,
@@ -361,43 +391,66 @@ class SpencerFanoSolver:
         # partial final bin covering frac of a cell, truncated where the window leaves the top
         # of the grid. The uniform grid makes k and frac the same for every row, and the value
         # written at (i, j) is vec[j], independent of the row, so the whole contribution is a
-        # constant-width band of one 1D vector: one windowed addition for the full-weight band
-        # and one matrix diagonal for the partial bins, with a row-by-row fill only for the
-        # rows truncated by the excitation threshold (i < r0) or clipped at the top of the
-        # grid (i >= bandstop).
+        # constant-width band of one 1D vector.
         k = int(epsilon_trans_ev / self.deltaen)
         frac = epsilon_trans_ev / self.deltaen - k
-        bandstop = max(npts - k, 0)  # rows from here on have their window clipped at the top of the grid
-        r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
-        nrows = bandstop - r0
-        self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
-        # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
-        # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
-        flat = self.sfmatrix.reshape(-1, copy=False)
-        flatstart = r0 * (npts + 1)
-        if 0 < k < npts:
-            # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
-            band = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
-            band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
-        fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
-        fracdiag += vec[r0 + k : bandstop + k] * frac
-        self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
+
+        if k < min(EXCITATION_BAND_ACCUM_MAX_ROWS, npts):
+            # sum this transition into the per-offset buffer instead of the matrix: element
+            # (i, i + d) takes vec[i + d], so buffer row d needs vec[j] over the columns
+            # j >= max(xsstartindex, d) at full weight for d < k, and vec[j] * frac on row k
+            # over j >= k (rows i >= npts - k have their window clipped at the top of the grid
+            # and every remaining bin at full width, which the column bound j <= npts - 1
+            # already encodes). Buffer cells accumulate transitions in the order they are
+            # added, so flushing gives the same entries as adding each band to the matrix
+            # directly would.
+            band = self._excitation_band
+            if band is None:
+                band = self._excitation_band = np.zeros((min(EXCITATION_BAND_ACCUM_MAX_ROWS, npts), npts))
+            self._excitation_band_nrows = max(self._excitation_band_nrows, k + 1)
+            band[: min(k, xsstartindex), xsstartindex:] += vec[xsstartindex:]
+            for d in range(min(k, xsstartindex), k):
+                band[d, d:] += vec[d:]
+            band[k, k:] += vec[k:] * frac
+        else:
+            # a band too wide for the buffer is written to the matrix directly: one windowed
+            # addition for the full-weight band and one matrix diagonal for the partial bins,
+            # with a row-by-row fill for the rows truncated by the excitation threshold
+            # (i < r0) or clipped at the top of the grid (i >= bandstop). Any buffered
+            # transitions must land first so that every matrix entry accumulates its
+            # transitions in the order they were added.
+            self._flush_excitation_band()
+            bandstop = max(npts - k, 0)
+            r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
+            nrows = bandstop - r0
+            self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
+            # the matrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
+            # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
+            flat = self._sfmatrix.reshape(-1, copy=False)
+            flatstart = r0 * (npts + 1)
+            if 0 < k < npts:
+                # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
+                band_view = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
+                band_view += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
+            fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
+            fracdiag += vec[r0 + k : bandstop + k] * frac
+            self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
 
     def _excitation_fill_rows(
         self, rows: range, vec: npt.NDArray[np.float64], xsstartindex: int, k: int, frac: float
     ) -> None:
-        # row-by-row fill for one excitation transition, for the rows the banded fast path in
+        # row-by-row fill for one excitation transition, for the rows the direct banded fill in
         # add_excitation cannot cover: rows truncated by the excitation threshold and rows
         # whose window is clipped at the top of the grid, where every remaining bin is full width
         npts = len(self.engrid)
         for i in rows:
             startindex = max(i, xsstartindex)
             if i + k < npts:
-                self.sfmatrix[i, startindex : i + k] += vec[startindex : i + k]
+                self._sfmatrix[i, startindex : i + k] += vec[startindex : i + k]
                 # the final bin [E_i + k * deltaen, E_i + epsilon_trans_ev] covers frac of a cell
-                self.sfmatrix[i, i + k] += vec[i + k] * frac
+                self._sfmatrix[i, i + k] += vec[i + k] * frac
             else:
-                self.sfmatrix[i, startindex:] += vec[startindex:]
+                self._sfmatrix[i, startindex:] += vec[startindex:]
 
     def add_ion_ltepopexcitation(
         self,
@@ -556,6 +609,7 @@ class SpencerFanoSolver:
         # non-decreasing epsilon_uppers.
         cut1 = 0  # end of the first integral's non-empty column range, clamped to jstart per row
         top_en_plus_deltaen = self.engrid[-1] + deltaen
+        sfmatrix = self.sfmatrix  # applies pending excitation contributions once, before the row loop
         for i, en in enumerate(self.engrid):
             # endash ranges from en to SF_EMAX, but skip over the zero-cross section points
             jstart = max(i, xsstartindex)
@@ -567,7 +621,7 @@ class SpencerFanoSolver:
             cut1 = max(cut1, jstart)
             while cut1 < npts and epsilon_lowers1[cut1 - i] <= epsilon_uppers[cut1]:
                 cut1 += 1
-            self.sfmatrix[i, jstart:cut1] += prefactors[jstart:cut1] * (
+            sfmatrix[i, jstart:cut1] += prefactors[jstart:cut1] * (
                 int_eps_uppers[jstart:cut1] - int_eps_lowers1[jstart - i : cut1 - i]
             )
 
@@ -581,7 +635,7 @@ class SpencerFanoSolver:
                 epsilon_lower2 = en + ionpot_ev
                 int_eps_lower2 = math.atan((epsilon_lower2 - ionpot_ev) / J)
                 jstart2 = max(secondintegralstartindex, int(np.searchsorted(epsilon_uppers, epsilon_lower2)))
-                self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
+                sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
 
     def add_ionisation(self, Z: int, ion_stage: int, n_ion: float) -> None:
         self._require_not_solved("add ionisation")

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -247,23 +247,23 @@ class SpencerFanoSolver:
     def electronlossfunction(self, en_ev: float) -> float:
         return electronlossfunction(en_ev, self.get_n_e())
 
-    def _require_solved(self) -> None:
+    def require_solved(self) -> None:
         if not self._solved:
             msg = "The Spencer-Fano equation must be solved first. Call solve()."
             raise RuntimeError(msg)
 
-    def _require_not_solved(self, action: str) -> None:
+    def require_not_solved(self, action: str) -> None:
         if self._solved:
             msg = f"Can't {action} after solving the Spencer-Fano equation"
             raise RuntimeError(msg)
 
-    def _get_all_ions(self) -> list[tuple[int, int]]:
+    def get_all_ions(self) -> list[tuple[int, int]]:
         # every ion with an ionisation or an excitation channel: ions with a registered population
         # first (in population registration order), then ions that only have manually-added
         # excitation channels (in the order their first excitation was added)
         return list(dict.fromkeys([*self.ionpopdict, *self.excitationlists]))
 
-    def _register_ion_population(self, Z: int, ion_stage: int, n_ion: float) -> None:
+    def register_ion_population(self, Z: int, ion_stage: int, n_ion: float) -> None:
         # an ion's number density must agree between its ionisation and excitation calls
         if n_ion < 0.0:
             msg = f"n_ion must be non-negative but is {n_ion}"
@@ -278,7 +278,7 @@ class SpencerFanoSolver:
         # the free electron density derived from the ion populations is no longer current
         self._n_e = None
 
-    def _get_ion_collion_rows(self, Z: int, ion_stage: int) -> list[dict[str, t.Any]]:
+    def get_ion_collion_rows(self, Z: int, ion_stage: int) -> list[dict[str, t.Any]]:
         # collisional ionisation shell data rows for one ion (cached)
         key = (Z, ion_stage)
         if key not in self._collionrows_ion:
@@ -287,7 +287,7 @@ class SpencerFanoSolver:
             ).to_dicts()
         return self._collionrows_ion[key]
 
-    def _get_shell_xs(self, shell: dict[str, t.Any]) -> npt.NDArray[np.float64]:
+    def get_shell_xs(self, shell: dict[str, t.Any]) -> npt.NDArray[np.float64]:
         # ionisation cross sections on the energy grid for one shell (cached)
         key = (int(shell["Z"]), int(shell["ion_stage"]), int(shell["n"]), int(shell["l"]), float(shell["ionpot_ev"]))
         if key not in self._shell_xs:
@@ -314,7 +314,7 @@ class SpencerFanoSolver:
         transitionkey:
             any key to uniquely identify the transition so that the rate coefficient can be retrieved later
         """
-        self._require_not_solved("add excitation")
+        self.require_not_solved("add excitation")
         if len(xs_vec) != len(self.engrid):
             msg = f"xs_vec has {len(xs_vec)} points but engrid has {len(self.engrid)}"
             raise ValueError(msg)
@@ -370,7 +370,7 @@ class SpencerFanoSolver:
         bandstop = max(npts - k, 0)  # rows from here on have their window clipped at the top of the grid
         r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
         nrows = bandstop - r0
-        self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
+        self.excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
         # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
         # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
         flat = self.sfmatrix.reshape(-1, copy=False)
@@ -381,9 +381,9 @@ class SpencerFanoSolver:
             band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
         fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
         fracdiag += vec[r0 + k : bandstop + k] * frac
-        self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
+        self.excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
 
-    def _excitation_fill_rows(
+    def excitation_fill_rows(
         self, rows: range, vec: npt.NDArray[np.float64], xsstartindex: int, k: int, frac: float
     ) -> None:
         # row-by-row fill for one excitation transition, for the rows the banded fast path in
@@ -419,7 +419,7 @@ class SpencerFanoSolver:
         fine-structure transitions far below any usable emin_ev. Pass verbose=True to the solver to see how
         many transitions were dropped.
         """
-        self._require_not_solved("add excitation")
+        self.require_not_solved("add excitation")
         if adata_polars is not None:
             self.adata_polars = adata_polars
 
@@ -440,7 +440,7 @@ class SpencerFanoSolver:
 
         # register the population so that this ion counts towards n_e and n_ion_tot even when
         # add_ionisation() was never called for it
-        self._register_ion_population(Z, ion_stage, n_ion)
+        self.register_ion_population(Z, ion_stage, n_ion)
 
         dfpops_thision = ion["levels"].item()
 
@@ -506,15 +506,15 @@ class SpencerFanoSolver:
                     transitionkey=(transition["lower"], transition["upper"]),
                 )
 
-    def _add_ionisation_shell(self, n_ion: float, shell: dict[str, int | float]) -> None:
+    def add_ionisation_shell(self, n_ion: float, shell: dict[str, int | float]) -> None:
         # add the terms related to ionisation cross sections for one shell
-        self._require_not_solved("add ionisation")
+        self.require_not_solved("add ionisation")
         deltaen = self.deltaen
         ionpot_ev = float(shell["ionpot_ev"])
         J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
         npts = len(self.engrid)
 
-        ar_xs_array = self._get_shell_xs(shell)
+        ar_xs_array = self.get_shell_xs(shell)
 
         xsstartindex = 0 if ionpot_ev <= self.engrid[0] else self.get_energyindex_gteq(en_ev=ionpot_ev)
 
@@ -584,7 +584,7 @@ class SpencerFanoSolver:
                 self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
 
     def add_ionisation(self, Z: int, ion_stage: int, n_ion: float) -> None:
-        self._require_not_solved("add ionisation")
+        self.require_not_solved("add ionisation")
         if (Z, ion_stage) in self._ionisation_ions:
             msg = f"Can't add Z={Z} ion_stage {ion_stage} twice"
             raise ValueError(msg)
@@ -594,7 +594,7 @@ class SpencerFanoSolver:
             msg = f"n_ion must be non-negative but is {n_ion}"
             raise ValueError(msg)
 
-        collionrows = self._get_ion_collion_rows(Z, ion_stage)
+        collionrows = self.get_ion_collion_rows(Z, ion_stage)
         if not collionrows:
             msg = f"No ionisation cross-section data for Z={Z} ion_stage {ion_stage}"
             raise ValueError(msg)
@@ -620,11 +620,11 @@ class SpencerFanoSolver:
                 f" {ion_stage} ({at.get_ionstring(Z, ion_stage)}) ionisation with n_ion"
                 f" {n_ion:.1e} [/cm3]"
             )
-        self._register_ion_population(Z, ion_stage, n_ion)
+        self.register_ion_population(Z, ion_stage, n_ion)
         self._ionisation_ions.add((Z, ion_stage))
 
         for shell in collionrows:
-            self._add_ionisation_shell(n_ion, shell)
+            self.add_ionisation_shell(n_ion, shell)
 
     def calculate_free_electron_density(self) -> float:
         # number density of free electrons [cm-^3]
@@ -727,7 +727,7 @@ class SpencerFanoSolver:
         return np.dot(xs_excitation_vec_sum_alltrans, self.yvec) * deltaen / self.depositionratedensity_ev
 
     @staticmethod
-    def _npts_subgrid(width_ev: float, J: float) -> int:
+    def npts_subgrid(width_ev: float, J: float) -> int:
         # nodes for a sub-grid spanning width_ev, given that the integrand varies on the scale of J.
         # Odd, so that a Simpson-style rule would see whole panels.
         npts = int(np.clip(NPTS_SUBGRID_PER_J * width_ev / J, NPTS_SUBGRID_MIN, NPTS_SUBGRID_MAX))
@@ -735,7 +735,7 @@ class SpencerFanoSolver:
         return npts + 1 - npts % 2
 
     @staticmethod
-    def _integrate_shell_secondaries(
+    def integrate_shell_secondaries(
         arr_e_p: npt.NDArray[np.float64],
         arr_y: npt.NDArray[np.float64],
         arr_xs: npt.NDArray[np.float64],
@@ -765,7 +765,7 @@ class SpencerFanoSolver:
         deltaen = float(self.deltaen)
         lastindex = len(self.engrid) - 2
 
-        for Z, ion_stage in self._get_all_ions():
+        for Z, ion_stage in self.get_all_ions():
             N_e_ion = 0.0
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
 
@@ -794,7 +794,7 @@ class SpencerFanoSolver:
             if (Z, ion_stage) not in self._ionisation_ions:
                 continue
 
-            for shell in self._get_ion_collion_rows(Z, ion_stage):
+            for shell in self.get_ion_collion_rows(Z, ion_stage):
                 ionpot_ev = float(shell["ionpot_ev"])
 
                 enlambda = min(e_max - energy_ev, energy_ev + ionpot_ev)
@@ -807,13 +807,13 @@ class SpencerFanoSolver:
                 # magnitude, depending on where the grid points happened to fall relative to ionpot_ev.
                 if enlambda > ionpot_ev:
                     arr_epsilon = np.linspace(
-                        ionpot_ev, enlambda, num=self._npts_subgrid(enlambda - ionpot_ev, J), dtype=np.float64
+                        ionpot_ev, enlambda, num=self.npts_subgrid(enlambda - ionpot_ev, J), dtype=np.float64
                     )
                     arr_e_p = energy_ev + arr_epsilon
                     # every node here lies between grid points, so y is interpolated and the cross section
                     # evaluated directly, the latter because it rises steeply from zero just above the
                     # ionisation threshold that starts this integral
-                    N_e_ion += self._integrate_shell_secondaries(
+                    N_e_ion += self.integrate_shell_secondaries(
                         arr_e_p=arr_e_p,
                         # asarray because np.interp is typed as returning a scalar for a scalar x
                         arr_y=np.asarray(np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)),
@@ -839,9 +839,9 @@ class SpencerFanoSolver:
                     stopindex = min(startindex + NCELLS_SECOND_INTEGRAL_SUBGRID, len(self.engrid) - 1)
                     en_upper_low = float(self.engrid[stopindex])
                     arr_e_p_low = np.linspace(
-                        en_lower2, en_upper_low, num=self._npts_subgrid(en_upper_low - en_lower2, J), dtype=np.float64
+                        en_lower2, en_upper_low, num=self.npts_subgrid(en_upper_low - en_lower2, J), dtype=np.float64
                     )
-                    N_e_ion += self._integrate_shell_secondaries(
+                    N_e_ion += self.integrate_shell_secondaries(
                         arr_e_p=arr_e_p_low,
                         arr_y=np.asarray(np.interp(arr_e_p_low, self.engrid, self.yvec, left=0.0, right=0.0)),
                         arr_xs=pynonthermal.collion.get_arxs_array_shell(arr_e_p_low, shell),
@@ -852,10 +852,10 @@ class SpencerFanoSolver:
                     # the rest is smooth on the scale of J, so y and the cross section come straight
                     # from the solution and the cache rather than being re-evaluated
                     if stopindex < len(self.engrid) - 1:
-                        N_e_ion += self._integrate_shell_secondaries(
+                        N_e_ion += self.integrate_shell_secondaries(
                             arr_e_p=self.engrid[stopindex:],
                             arr_y=self.yvec[stopindex:],
-                            arr_xs=self._get_shell_xs(shell)[stopindex:],
+                            arr_xs=self.get_shell_xs(shell)[stopindex:],
                             e_s=energy_ev,
                             ionpot_ev=ionpot_ev,
                             J=J,
@@ -904,7 +904,7 @@ class SpencerFanoSolver:
         self._frac_heating = frac_heating
         return frac_heating
 
-    def _reset_channel_fractions(self) -> None:
+    def reset_channel_fractions(self) -> None:
         # clear the per-ion accumulators, which analyse_ntspectrum() sums into
         self._analysed = False
         self._frac_ionisation_tot = 0.0
@@ -915,13 +915,13 @@ class SpencerFanoSolver:
         self._eff_ionpot = {}
 
     def reset_solution_analysis(self) -> None:
-        self._reset_channel_fractions()
+        self.reset_channel_fractions()
         self._frac_heating = None
 
     def analyse_ntspectrum(self) -> None:
-        self._require_solved()
+        self.require_solved()
         # keep any frac_heating already computed for this solution, since it only depends on yvec
-        self._reset_channel_fractions()
+        self.reset_channel_fractions()
 
         deltaen = self.deltaen
 
@@ -929,11 +929,11 @@ class SpencerFanoSolver:
             print(f"    n_e_nt: {self.get_n_e_nt():.2e} [/cm3]")
 
         n_ion_tot = self.get_n_ion_tot()
-        for Z, ion_stage in self._get_all_ions():
+        for Z, ion_stage in self.get_all_ions():
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
             X_ion = n_ion / n_ion_tot if n_ion_tot > 0.0 else 0.0
             # an ion added only for excitation has no ionisation shells in the matrix
-            collionrows = self._get_ion_collion_rows(Z, ion_stage) if (Z, ion_stage) in self._ionisation_ions else []
+            collionrows = self.get_ion_collion_rows(Z, ion_stage) if (Z, ion_stage) in self._ionisation_ions else []
 
             ionpot_valence = min((float(shell["ionpot_ev"]) for shell in collionrows), default=None)
 
@@ -949,7 +949,7 @@ class SpencerFanoSolver:
             self._frac_ionisation_ion[(Z, ion_stage)] = 0.0
             eta_over_ionpot_sum = 0.0
             for shell in collionrows:
-                ar_xs_array = self._get_shell_xs(shell)
+                ar_xs_array = self.get_shell_xs(shell)
 
                 frac_ionisation_shell = (
                     n_ion
@@ -1054,41 +1054,41 @@ class SpencerFanoSolver:
 
     def get_n_e_nt(self) -> float:
         """Get the number density of non-thermal electrons in cm^-3."""
-        self._require_solved()
+        self.require_solved()
         arr_velocity = CLIGHT * np.sqrt(get_betasq(self.engrid))  # cm/s
 
         return float(np.sum(self.yvec / arr_velocity) * self.deltaen)
 
     def get_frac_heating(self) -> float:
-        self._require_solved()
+        self.require_solved()
         if self._frac_heating is None:
             return self.calculate_frac_heating()
 
         return self._frac_heating
 
     def get_frac_excitation_tot(self) -> float:
-        self._require_solved()
+        self.require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
         return self._frac_excitation_tot
 
     def get_frac_ionisation_tot(self) -> float:
-        self._require_solved()
+        self.require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
         return self._frac_ionisation_tot
 
     def get_frac_ionisation_ion(self, Z: int, ion_stage: int) -> float:
-        self._require_solved()
+        self.require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
         return self._frac_ionisation_ion[(Z, ion_stage)]
 
     def get_eff_ionpot(self, Z: int, ion_stage: int) -> float:
-        self._require_solved()
+        self.require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
@@ -1099,7 +1099,7 @@ class SpencerFanoSolver:
 
         This scales with depositionratedensity_ev.
         """
-        self._require_solved()
+        self.require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
@@ -1111,7 +1111,7 @@ class SpencerFanoSolver:
         This is the integral of y(E) * sigma(E) dE in Kozma & Fransson equation 9, matching the
         convention of get_ionisation_ratecoeff(). It scales with depositionratedensity_ev.
         """
-        self._require_solved()
+        self.require_solved()
         _levelnumberdensity, xsvec, _epsilon_trans_ev = self.excitationlists[(Z, ion_stage)][transitionkey]
 
         return float(np.dot(xsvec, self.yvec) * self.deltaen)
@@ -1120,14 +1120,14 @@ class SpencerFanoSolver:
         return self.get_frac_heating() + self.get_frac_excitation_tot() + self.get_frac_ionisation_tot()
 
     def get_d_etaheating_by_d_en_vec(self) -> list[float]:
-        self._require_solved()
+        self.require_solved()
         return [
             self.electronlossfunction(self.engrid[i]) * self.yvec[i] / self.depositionratedensity_ev
             for i in range(len(self.engrid))
         ]
 
     def get_d_etaexcitation_by_d_en_vec(self) -> npt.NDArray[np.float64]:
-        self._require_solved()
+        self.require_solved()
         part_integrand = np.zeros(len(self.engrid))
 
         for Z, ion_stage in self.excitationlists:
@@ -1141,14 +1141,14 @@ class SpencerFanoSolver:
         return self.yvec * part_integrand
 
     def get_d_etaion_by_d_en_vec(self) -> npt.NDArray[np.float64]:
-        self._require_solved()
+        self.require_solved()
         part_integrand = np.zeros(len(self.engrid))
 
         for Z, ion_stage in self._ionisation_ions:
             n_ion = self.ionpopdict[(Z, ion_stage)]
 
-            for shell in self._get_ion_collion_rows(Z, ion_stage):
-                xsvec = self._get_shell_xs(shell)
+            for shell in self.get_ion_collion_rows(Z, ion_stage):
+                xsvec = self.get_shell_xs(shell)
 
                 part_integrand += n_ion * shell["ionpot_ev"] * xsvec / self.depositionratedensity_ev
 
@@ -1161,7 +1161,7 @@ class SpencerFanoSolver:
         outputfilename: Path | str | None = None,
         axis: mplax.Axes | None = None,
     ) -> None:
-        self._require_solved()
+        self.require_solved()
         fs = 12
         fig = None
         if axis is None:
@@ -1204,7 +1204,7 @@ class SpencerFanoSolver:
     def plot_channels(
         self, outputfilename: Path | str | None = None, axis: mplax.Axes | None = None, xscalelog: bool = False
     ) -> None:
-        self._require_solved()
+        self.require_solved()
         fs = 12
         fig = None
         if axis is None:

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -314,6 +314,21 @@ class SpencerFanoSolver:
         transitionkey:
             any key to uniquely identify the transition so that the rate coefficient can be retrieved later
         """
+        vec, k, frac = self._store_excitation(Z, ion_stage, levelnumberdensity, xs_vec, epsilon_trans_ev, transitionkey)
+        self._add_excitation_band(vec, vec * frac, k)
+
+    def _store_excitation(
+        self,
+        Z: int,
+        ion_stage: int,
+        levelnumberdensity: float,
+        xs_vec: npt.NDArray[np.float64],
+        epsilon_trans_ev: float,
+        transitionkey: t.Any | None,
+    ) -> tuple[npt.NDArray[np.float64], int, float]:
+        # validate and record one transition, and describe its matrix band: the values vec[j]
+        # (zeroed below the threshold index, where no grid electron can drive the transition),
+        # the band width k in whole bins, and the weight frac of the partial final bin
         self._require_not_solved("add excitation")
         if len(xs_vec) != len(self.engrid):
             msg = f"xs_vec has {len(xs_vec)} points but engrid has {len(self.engrid)}"
@@ -354,50 +369,33 @@ class SpencerFanoSolver:
             epsilon_trans_ev,
         )
         vec = levelnumberdensity * self.deltaen * xs_vec  # cross section times level density times bin width
-        xsstartindex = self.get_energyindex_lteq(en_ev=epsilon_trans_ev)
-        npts = len(self.engrid)
-
-        # row i's integral runs over [E_i, E_i + epsilon_trans_ev]: k full-width bins and a
-        # partial final bin covering frac of a cell, truncated where the window leaves the top
-        # of the grid. The uniform grid makes k and frac the same for every row, and the value
-        # written at (i, j) is vec[j], independent of the row, so the whole contribution is a
-        # constant-width band of one 1D vector: one windowed addition for the full-weight band
-        # and one matrix diagonal for the partial bins, with a row-by-row fill only for the
-        # rows truncated by the excitation threshold (i < r0) or clipped at the top of the
-        # grid (i >= bandstop).
+        vec[: self.get_energyindex_lteq(en_ev=epsilon_trans_ev)] = 0.0
         k = int(epsilon_trans_ev / self.deltaen)
         frac = epsilon_trans_ev / self.deltaen - k
+        return vec, k, frac
+
+    def _add_excitation_band(self, vec: npt.NDArray[np.float64], fracvec: npt.NDArray[np.float64], k: int) -> None:
+        # add one excitation band to the matrix. Row i's integral runs over
+        # [E_i, E_i + epsilon_trans_ev]: k full-width bins taking vec[j] at columns
+        # j in [i, i + k), plus a partial final bin taking fracvec[i + k], truncated where the
+        # window leaves the top of the grid (every remaining bin then counts at full width).
+        # The uniform grid makes the band geometry the same for every row, so the whole
+        # contribution is one windowed addition plus one matrix diagonal, with a row loop only
+        # for the clipped rows. The band values add linearly, so vec and fracvec may also hold
+        # the pre-summed contributions of many transitions that share the same k.
+        npts = len(self.engrid)
         bandstop = max(npts - k, 0)  # rows from here on have their window clipped at the top of the grid
-        r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
-        nrows = bandstop - r0
-        self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
         # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
         # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
         flat = self.sfmatrix.reshape(-1, copy=False)
-        flatstart = r0 * (npts + 1)
         if 0 < k < npts:
-            # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
-            band = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
-            band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
-        fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
-        fracdiag += vec[r0 + k : bandstop + k] * frac
-        self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
-
-    def _excitation_fill_rows(
-        self, rows: range, vec: npt.NDArray[np.float64], xsstartindex: int, k: int, frac: float
-    ) -> None:
-        # row-by-row fill for one excitation transition, for the rows the banded fast path in
-        # add_excitation cannot cover: rows truncated by the excitation threshold and rows
-        # whose window is clipped at the top of the grid, where every remaining bin is full width
-        npts = len(self.engrid)
-        for i in rows:
-            startindex = max(i, xsstartindex)
-            if i + k < npts:
-                self.sfmatrix[i, startindex : i + k] += vec[startindex : i + k]
-                # the final bin [E_i + k * deltaen, E_i + epsilon_trans_ev] covers frac of a cell
-                self.sfmatrix[i, i + k] += vec[i + k] * frac
-            else:
-                self.sfmatrix[i, startindex:] += vec[startindex:]
+            # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [0, bandstop)
+            band = flat[: bandstop * (npts + 1)].reshape(bandstop, npts + 1)[:, :k]
+            band += np.lib.stride_tricks.sliding_window_view(vec, k)[:bandstop]
+        fracdiag = flat[k :: npts + 1][:bandstop]  # elements sfmatrix[i, i + k]
+        fracdiag += fracvec[k : bandstop + k]
+        for i in range(bandstop, npts):
+            self.sfmatrix[i, i:] += vec[i:]
 
     def add_ion_ltepopexcitation(
         self,
@@ -492,19 +490,32 @@ class SpencerFanoSolver:
                     f" {maxnlevelsupper})"
                 )
 
+            # writing a band sweeps a strip of the whole npts x npts matrix and dominates the
+            # cost of this method when done once per transition. Transitions with the same
+            # band width k share identical matrix geometry and their band values add
+            # linearly, so each distinct k is written once, with the vectors pre-summed.
+            groups: dict[int, tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}
+            npts = len(self.engrid)
             for transition in dftransitions.iter_rows(named=True):
-                epsilon_trans_ev = transition["epsilon_trans_ev"]
                 xs_vec = pynonthermal.excitation.get_xs_excitation_vector(
                     self.engrid, transition, use_collstrengths=use_collstrengths
                 )
-                self.add_excitation(
+                vec, k, frac = self._store_excitation(
                     Z,
                     ion_stage,
                     transition["lower_pop"],
                     xs_vec,
-                    epsilon_trans_ev,
+                    transition["epsilon_trans_ev"],
                     transitionkey=(transition["lower"], transition["upper"]),
                 )
+                if k not in groups:
+                    groups[k] = (np.zeros(npts), np.zeros(npts))
+                groupvec, groupfracvec = groups[k]
+                groupvec += vec
+                groupfracvec += vec * frac
+
+            for k, (groupvec, groupfracvec) in sorted(groups.items()):
+                self._add_excitation_band(groupvec, groupfracvec, k)
 
     def _add_ionisation_shell(self, n_ion: float, shell: dict[str, int | float]) -> None:
         # add the terms related to ionisation cross sections for one shell

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -357,60 +357,47 @@ class SpencerFanoSolver:
         xsstartindex = self.get_energyindex_lteq(en_ev=epsilon_trans_ev)
         npts = len(self.engrid)
 
-        # the uniform grid makes every row's stop index expressible in one vectorised operation
-        stopindices = np.clip(
-            np.floor((self.engrid + epsilon_trans_ev - self.engrid[0]) / self.deltaen).astype(np.int64), 0, npts - 1
-        )
-        # clamp to deltaen for rows where en + epsilon_trans_ev extends beyond the top of the
-        # grid (the excitation integral is truncated at the grid boundary)
-        delta_en_actuals = np.minimum(self.engrid + epsilon_trans_ev - self.engrid[stopindices], self.deltaen)
-
-        # the value written at (i, j) is vec[j], independent of the row: row i covers columns
-        # [max(i, xsstartindex), stopindex(i)) at full weight plus a partial final bin at
-        # stopindex(i), and on the uniform grid stopindex(i) = min(i + k, npts - 1). The whole
-        # contribution is therefore a constant-width band of one 1D vector, written below as one
-        # windowed addition (plus one matrix diagonal for the partial bins) instead of npts row
-        # slices. Only the rows truncated by the excitation threshold (i < r0) or clipped at the
-        # top of the grid (i >= bandstop) need the row-by-row fill.
-        k = int(stopindices[0])
-        if np.array_equal(stopindices, np.minimum(np.arange(npts) + k, npts - 1)):
-            bandstop = npts - k  # rows before this have their stop index unclipped at min(i + k, npts - 1) = i + k
-            r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
-            nrows = bandstop - r0
-            self._excitation_fill_rows(range(r0), vec, xsstartindex, stopindices, delta_en_actuals)
-            # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
-            # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
-            flat = self.sfmatrix.reshape(-1, copy=False)
-            flatstart = r0 * (npts + 1)
-            if k > 0:
-                # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
-                band = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
-                band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
-            fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
-            fracdiag += vec[r0 + k : bandstop + k] * delta_en_actuals[r0:bandstop] / self.deltaen
-            self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, stopindices, delta_en_actuals)
-        else:
-            # float rounding in the stop indices broke the constant band width; fall back to the
-            # row-by-row fill, which makes no assumption about the band structure
-            self._excitation_fill_rows(range(npts), vec, xsstartindex, stopindices, delta_en_actuals)
+        # row i's integral runs over [E_i, E_i + epsilon_trans_ev]: k full-width bins and a
+        # partial final bin covering frac of a cell, truncated where the window leaves the top
+        # of the grid. The uniform grid makes k and frac the same for every row, and the value
+        # written at (i, j) is vec[j], independent of the row, so the whole contribution is a
+        # constant-width band of one 1D vector: one windowed addition for the full-weight band
+        # and one matrix diagonal for the partial bins, with a row-by-row fill only for the
+        # rows truncated by the excitation threshold (i < r0) or clipped at the top of the
+        # grid (i >= bandstop).
+        k = int(epsilon_trans_ev / self.deltaen)
+        frac = epsilon_trans_ev / self.deltaen - k
+        bandstop = max(npts - k, 0)  # rows from here on have their window clipped at the top of the grid
+        r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
+        nrows = bandstop - r0
+        self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
+        # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
+        # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
+        flat = self.sfmatrix.reshape(-1, copy=False)
+        flatstart = r0 * (npts + 1)
+        if 0 < k < npts:
+            # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
+            band = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
+            band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
+        fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
+        fracdiag += vec[r0 + k : bandstop + k] * frac
+        self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
 
     def _excitation_fill_rows(
-        self,
-        rows: range,
-        vec: npt.NDArray[np.float64],
-        xsstartindex: int,
-        stopindices: npt.NDArray[np.int64],
-        delta_en_actuals: npt.NDArray[np.float64],
+        self, rows: range, vec: npt.NDArray[np.float64], xsstartindex: int, k: int, frac: float
     ) -> None:
-        # row-by-row fill for one excitation transition, used for the rows the banded fast path
-        # in add_excitation cannot cover and as its fallback
+        # row-by-row fill for one excitation transition, for the rows the banded fast path in
+        # add_excitation cannot cover: rows truncated by the excitation threshold and rows
+        # whose window is clipped at the top of the grid, where every remaining bin is full width
+        npts = len(self.engrid)
         for i in rows:
-            stopindex = stopindices[i]
             startindex = max(i, xsstartindex)
-            self.sfmatrix[i, startindex:stopindex] += vec[startindex:stopindex]
-
-            # do the last bit separately because we're not using the full deltaen interval
-            self.sfmatrix[i, stopindex] += vec[stopindex] * delta_en_actuals[i] / self.deltaen
+            if i + k < npts:
+                self.sfmatrix[i, startindex : i + k] += vec[startindex : i + k]
+                # the final bin [E_i + k * deltaen, E_i + epsilon_trans_ev] covers frac of a cell
+                self.sfmatrix[i, i + k] += vec[i + k] * frac
+            else:
+                self.sfmatrix[i, startindex:] += vec[startindex:]
 
     def add_ion_ltepopexcitation(
         self,

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -589,7 +589,7 @@ class SpencerFanoSolver:
                 # at each endash, the integral in epsilon ranges from
                 # epsilon_lower = en + ionpot_ev
                 # epsilon_upper = min((endash + ionpot_ev) / 2, endash)]
-                epsilon_lower2 = en + ionpot_ev
+                epsilon_lower2 = float(en + ionpot_ev)
                 int_eps_lower2 = math.atan((epsilon_lower2 - ionpot_ev) / J)
                 jstart2 = max(secondintegralstartindex, int(np.searchsorted(epsilon_uppers, epsilon_lower2)))
                 self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -40,13 +40,6 @@ NCELLS_SECOND_INTEGRAL_SUBGRID: int = 2
 # emin_ev was below the grid spacing and several hundred when it was well above.
 NPTS_SUB_E0_INTEGRAL: int = 9
 
-# Excitation contributions are summed per band offset in a small cache-resident buffer and
-# applied to the matrix in one pass per offset when the matrix is next read, instead of
-# sweeping a strip of the whole npts x npts matrix once per transition. The buffer covers
-# bands up to this many offsets; the rare wider bands (epsilon_trans_ev of hundreds of eV at
-# the default grid spacing) are written to the matrix directly.
-EXCITATION_BAND_ACCUM_MAX_ROWS: int = 256
-
 SUBSHELLNAMES = [
     "K ",
     "L1",
@@ -159,9 +152,7 @@ class SpencerFanoSolver:
     dfcollion: pl.DataFrame
     rhsvec: npt.NDArray[np.float64]
     E_init_ev: float
-    _sfmatrix: npt.NDArray[np.float64]
-    _excitation_band: npt.NDArray[np.float64] | None
-    _excitation_band_nrows: int
+    sfmatrix: npt.NDArray[np.float64]
     adata_polars: pl.DataFrame | None
     yvec: npt.NDArray[np.float64]
 
@@ -238,9 +229,7 @@ class SpencerFanoSolver:
                 f" {source_emax:.2f} eV with E_init {self.E_init_ev:7.2f} [eV/s/cm3]"
             )
 
-        self._sfmatrix = np.zeros((npts, npts))
-        self._excitation_band = None
-        self._excitation_band_nrows = 0
+        self.sfmatrix = np.zeros((npts, npts))
 
     def __enter__(self) -> t.Self:
         """Enter the context manager."""
@@ -304,25 +293,6 @@ class SpencerFanoSolver:
         if key not in self._shell_xs:
             self._shell_xs[key] = pynonthermal.collion.get_arxs_array_shell(self.engrid, shell)
         return self._shell_xs[key]
-
-    @property
-    def sfmatrix(self) -> npt.NDArray[np.float64]:
-        """The Spencer-Fano matrix, with any pending excitation contributions applied."""
-        self._flush_excitation_band()
-        return self._sfmatrix
-
-    def _flush_excitation_band(self) -> None:
-        # apply the summed per-offset excitation contributions to the matrix: buffer row d
-        # holds the values of the matrix elements (i, i + d), i.e. the d-th superdiagonal
-        band = self._excitation_band
-        if band is None:
-            return
-        self._excitation_band = None
-        npts = len(self.engrid)
-        flat = self._sfmatrix.reshape(-1, copy=False)
-        for d in range(self._excitation_band_nrows):
-            flat[d :: npts + 1][: npts - d] += band[d, d:]
-        self._excitation_band_nrows = 0
 
     def add_excitation(
         self,
@@ -391,66 +361,43 @@ class SpencerFanoSolver:
         # partial final bin covering frac of a cell, truncated where the window leaves the top
         # of the grid. The uniform grid makes k and frac the same for every row, and the value
         # written at (i, j) is vec[j], independent of the row, so the whole contribution is a
-        # constant-width band of one 1D vector.
+        # constant-width band of one 1D vector: one windowed addition for the full-weight band
+        # and one matrix diagonal for the partial bins, with a row-by-row fill only for the
+        # rows truncated by the excitation threshold (i < r0) or clipped at the top of the
+        # grid (i >= bandstop).
         k = int(epsilon_trans_ev / self.deltaen)
         frac = epsilon_trans_ev / self.deltaen - k
-
-        if k < min(EXCITATION_BAND_ACCUM_MAX_ROWS, npts):
-            # sum this transition into the per-offset buffer instead of the matrix: element
-            # (i, i + d) takes vec[i + d], so buffer row d needs vec[j] over the columns
-            # j >= max(xsstartindex, d) at full weight for d < k, and vec[j] * frac on row k
-            # over j >= k (rows i >= npts - k have their window clipped at the top of the grid
-            # and every remaining bin at full width, which the column bound j <= npts - 1
-            # already encodes). Buffer cells accumulate transitions in the order they are
-            # added, so flushing gives the same entries as adding each band to the matrix
-            # directly would.
-            band = self._excitation_band
-            if band is None:
-                band = self._excitation_band = np.zeros((min(EXCITATION_BAND_ACCUM_MAX_ROWS, npts), npts))
-            self._excitation_band_nrows = max(self._excitation_band_nrows, k + 1)
-            band[: min(k, xsstartindex), xsstartindex:] += vec[xsstartindex:]
-            for d in range(min(k, xsstartindex), k):
-                band[d, d:] += vec[d:]
-            band[k, k:] += vec[k:] * frac
-        else:
-            # a band too wide for the buffer is written to the matrix directly: one windowed
-            # addition for the full-weight band and one matrix diagonal for the partial bins,
-            # with a row-by-row fill for the rows truncated by the excitation threshold
-            # (i < r0) or clipped at the top of the grid (i >= bandstop). Any buffered
-            # transitions must land first so that every matrix entry accumulates its
-            # transitions in the order they were added.
-            self._flush_excitation_band()
-            bandstop = max(npts - k, 0)
-            r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
-            nrows = bandstop - r0
-            self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
-            # the matrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
-            # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
-            flat = self._sfmatrix.reshape(-1, copy=False)
-            flatstart = r0 * (npts + 1)
-            if 0 < k < npts:
-                # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
-                band_view = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
-                band_view += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
-            fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
-            fracdiag += vec[r0 + k : bandstop + k] * frac
-            self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
+        bandstop = max(npts - k, 0)  # rows from here on have their window clipped at the top of the grid
+        r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
+        nrows = bandstop - r0
+        self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
+        # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
+        # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
+        flat = self.sfmatrix.reshape(-1, copy=False)
+        flatstart = r0 * (npts + 1)
+        if 0 < k < npts:
+            # rows of this view are the band segments sfmatrix[i, i:i+k] for i in [r0, bandstop)
+            band = flat[flatstart : flatstart + nrows * (npts + 1)].reshape(nrows, npts + 1)[:, :k]
+            band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
+        fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
+        fracdiag += vec[r0 + k : bandstop + k] * frac
+        self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
 
     def _excitation_fill_rows(
         self, rows: range, vec: npt.NDArray[np.float64], xsstartindex: int, k: int, frac: float
     ) -> None:
-        # row-by-row fill for one excitation transition, for the rows the direct banded fill in
+        # row-by-row fill for one excitation transition, for the rows the banded fast path in
         # add_excitation cannot cover: rows truncated by the excitation threshold and rows
         # whose window is clipped at the top of the grid, where every remaining bin is full width
         npts = len(self.engrid)
         for i in rows:
             startindex = max(i, xsstartindex)
             if i + k < npts:
-                self._sfmatrix[i, startindex : i + k] += vec[startindex : i + k]
+                self.sfmatrix[i, startindex : i + k] += vec[startindex : i + k]
                 # the final bin [E_i + k * deltaen, E_i + epsilon_trans_ev] covers frac of a cell
-                self._sfmatrix[i, i + k] += vec[i + k] * frac
+                self.sfmatrix[i, i + k] += vec[i + k] * frac
             else:
-                self._sfmatrix[i, startindex:] += vec[startindex:]
+                self.sfmatrix[i, startindex:] += vec[startindex:]
 
     def add_ion_ltepopexcitation(
         self,
@@ -609,7 +556,6 @@ class SpencerFanoSolver:
         # non-decreasing epsilon_uppers.
         cut1 = 0  # end of the first integral's non-empty column range, clamped to jstart per row
         top_en_plus_deltaen = self.engrid[-1] + deltaen
-        sfmatrix = self.sfmatrix  # applies pending excitation contributions once, before the row loop
         for i, en in enumerate(self.engrid):
             # endash ranges from en to SF_EMAX, but skip over the zero-cross section points
             jstart = max(i, xsstartindex)
@@ -621,7 +567,7 @@ class SpencerFanoSolver:
             cut1 = max(cut1, jstart)
             while cut1 < npts and epsilon_lowers1[cut1 - i] <= epsilon_uppers[cut1]:
                 cut1 += 1
-            sfmatrix[i, jstart:cut1] += prefactors[jstart:cut1] * (
+            self.sfmatrix[i, jstart:cut1] += prefactors[jstart:cut1] * (
                 int_eps_uppers[jstart:cut1] - int_eps_lowers1[jstart - i : cut1 - i]
             )
 
@@ -635,7 +581,7 @@ class SpencerFanoSolver:
                 epsilon_lower2 = en + ionpot_ev
                 int_eps_lower2 = math.atan((epsilon_lower2 - ionpot_ev) / J)
                 jstart2 = max(secondintegralstartindex, int(np.searchsorted(epsilon_uppers, epsilon_lower2)))
-                sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
+                self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
 
     def add_ionisation(self, Z: int, ion_stage: int, n_ion: float) -> None:
         self._require_not_solved("add ionisation")

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -247,23 +247,23 @@ class SpencerFanoSolver:
     def electronlossfunction(self, en_ev: float) -> float:
         return electronlossfunction(en_ev, self.get_n_e())
 
-    def require_solved(self) -> None:
+    def _require_solved(self) -> None:
         if not self._solved:
             msg = "The Spencer-Fano equation must be solved first. Call solve()."
             raise RuntimeError(msg)
 
-    def require_not_solved(self, action: str) -> None:
+    def _require_not_solved(self, action: str) -> None:
         if self._solved:
             msg = f"Can't {action} after solving the Spencer-Fano equation"
             raise RuntimeError(msg)
 
-    def get_all_ions(self) -> list[tuple[int, int]]:
+    def _get_all_ions(self) -> list[tuple[int, int]]:
         # every ion with an ionisation or an excitation channel: ions with a registered population
         # first (in population registration order), then ions that only have manually-added
         # excitation channels (in the order their first excitation was added)
         return list(dict.fromkeys([*self.ionpopdict, *self.excitationlists]))
 
-    def register_ion_population(self, Z: int, ion_stage: int, n_ion: float) -> None:
+    def _register_ion_population(self, Z: int, ion_stage: int, n_ion: float) -> None:
         # an ion's number density must agree between its ionisation and excitation calls
         if n_ion < 0.0:
             msg = f"n_ion must be non-negative but is {n_ion}"
@@ -278,7 +278,7 @@ class SpencerFanoSolver:
         # the free electron density derived from the ion populations is no longer current
         self._n_e = None
 
-    def get_ion_collion_rows(self, Z: int, ion_stage: int) -> list[dict[str, t.Any]]:
+    def _get_ion_collion_rows(self, Z: int, ion_stage: int) -> list[dict[str, t.Any]]:
         # collisional ionisation shell data rows for one ion (cached)
         key = (Z, ion_stage)
         if key not in self._collionrows_ion:
@@ -287,7 +287,7 @@ class SpencerFanoSolver:
             ).to_dicts()
         return self._collionrows_ion[key]
 
-    def get_shell_xs(self, shell: dict[str, t.Any]) -> npt.NDArray[np.float64]:
+    def _get_shell_xs(self, shell: dict[str, t.Any]) -> npt.NDArray[np.float64]:
         # ionisation cross sections on the energy grid for one shell (cached)
         key = (int(shell["Z"]), int(shell["ion_stage"]), int(shell["n"]), int(shell["l"]), float(shell["ionpot_ev"]))
         if key not in self._shell_xs:
@@ -314,7 +314,7 @@ class SpencerFanoSolver:
         transitionkey:
             any key to uniquely identify the transition so that the rate coefficient can be retrieved later
         """
-        self.require_not_solved("add excitation")
+        self._require_not_solved("add excitation")
         if len(xs_vec) != len(self.engrid):
             msg = f"xs_vec has {len(xs_vec)} points but engrid has {len(self.engrid)}"
             raise ValueError(msg)
@@ -370,7 +370,7 @@ class SpencerFanoSolver:
         bandstop = max(npts - k, 0)  # rows from here on have their window clipped at the top of the grid
         r0 = min(xsstartindex, bandstop)  # first row with an untruncated full-weight window
         nrows = bandstop - r0
-        self.excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
+        self._excitation_fill_rows(range(r0), vec, xsstartindex, k, frac)
         # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
         # i * (npts + 1) + d; copy=False makes reshape raise rather than silently write to a copy
         flat = self.sfmatrix.reshape(-1, copy=False)
@@ -381,9 +381,9 @@ class SpencerFanoSolver:
             band += np.lib.stride_tricks.sliding_window_view(vec[r0:], k)[:nrows]
         fracdiag = flat[flatstart + k :: npts + 1][:nrows]  # elements sfmatrix[i, i + k]
         fracdiag += vec[r0 + k : bandstop + k] * frac
-        self.excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
+        self._excitation_fill_rows(range(bandstop, npts), vec, xsstartindex, k, frac)
 
-    def excitation_fill_rows(
+    def _excitation_fill_rows(
         self, rows: range, vec: npt.NDArray[np.float64], xsstartindex: int, k: int, frac: float
     ) -> None:
         # row-by-row fill for one excitation transition, for the rows the banded fast path in
@@ -419,7 +419,7 @@ class SpencerFanoSolver:
         fine-structure transitions far below any usable emin_ev. Pass verbose=True to the solver to see how
         many transitions were dropped.
         """
-        self.require_not_solved("add excitation")
+        self._require_not_solved("add excitation")
         if adata_polars is not None:
             self.adata_polars = adata_polars
 
@@ -440,7 +440,7 @@ class SpencerFanoSolver:
 
         # register the population so that this ion counts towards n_e and n_ion_tot even when
         # add_ionisation() was never called for it
-        self.register_ion_population(Z, ion_stage, n_ion)
+        self._register_ion_population(Z, ion_stage, n_ion)
 
         dfpops_thision = ion["levels"].item()
 
@@ -506,15 +506,15 @@ class SpencerFanoSolver:
                     transitionkey=(transition["lower"], transition["upper"]),
                 )
 
-    def add_ionisation_shell(self, n_ion: float, shell: dict[str, int | float]) -> None:
+    def _add_ionisation_shell(self, n_ion: float, shell: dict[str, int | float]) -> None:
         # add the terms related to ionisation cross sections for one shell
-        self.require_not_solved("add ionisation")
+        self._require_not_solved("add ionisation")
         deltaen = self.deltaen
         ionpot_ev = float(shell["ionpot_ev"])
         J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
         npts = len(self.engrid)
 
-        ar_xs_array = self.get_shell_xs(shell)
+        ar_xs_array = self._get_shell_xs(shell)
 
         xsstartindex = 0 if ionpot_ev <= self.engrid[0] else self.get_energyindex_gteq(en_ev=ionpot_ev)
 
@@ -584,7 +584,7 @@ class SpencerFanoSolver:
                 self.sfmatrix[i, jstart2:] -= prefactors[jstart2:] * (int_eps_uppers[jstart2:] - int_eps_lower2)
 
     def add_ionisation(self, Z: int, ion_stage: int, n_ion: float) -> None:
-        self.require_not_solved("add ionisation")
+        self._require_not_solved("add ionisation")
         if (Z, ion_stage) in self._ionisation_ions:
             msg = f"Can't add Z={Z} ion_stage {ion_stage} twice"
             raise ValueError(msg)
@@ -594,7 +594,7 @@ class SpencerFanoSolver:
             msg = f"n_ion must be non-negative but is {n_ion}"
             raise ValueError(msg)
 
-        collionrows = self.get_ion_collion_rows(Z, ion_stage)
+        collionrows = self._get_ion_collion_rows(Z, ion_stage)
         if not collionrows:
             msg = f"No ionisation cross-section data for Z={Z} ion_stage {ion_stage}"
             raise ValueError(msg)
@@ -620,11 +620,11 @@ class SpencerFanoSolver:
                 f" {ion_stage} ({at.get_ionstring(Z, ion_stage)}) ionisation with n_ion"
                 f" {n_ion:.1e} [/cm3]"
             )
-        self.register_ion_population(Z, ion_stage, n_ion)
+        self._register_ion_population(Z, ion_stage, n_ion)
         self._ionisation_ions.add((Z, ion_stage))
 
         for shell in collionrows:
-            self.add_ionisation_shell(n_ion, shell)
+            self._add_ionisation_shell(n_ion, shell)
 
     def calculate_free_electron_density(self) -> float:
         # number density of free electrons [cm-^3]
@@ -727,7 +727,7 @@ class SpencerFanoSolver:
         return np.dot(xs_excitation_vec_sum_alltrans, self.yvec) * deltaen / self.depositionratedensity_ev
 
     @staticmethod
-    def npts_subgrid(width_ev: float, J: float) -> int:
+    def _npts_subgrid(width_ev: float, J: float) -> int:
         # nodes for a sub-grid spanning width_ev, given that the integrand varies on the scale of J.
         # Odd, so that a Simpson-style rule would see whole panels.
         npts = int(np.clip(NPTS_SUBGRID_PER_J * width_ev / J, NPTS_SUBGRID_MIN, NPTS_SUBGRID_MAX))
@@ -735,7 +735,7 @@ class SpencerFanoSolver:
         return npts + 1 - npts % 2
 
     @staticmethod
-    def integrate_shell_secondaries(
+    def _integrate_shell_secondaries(
         arr_e_p: npt.NDArray[np.float64],
         arr_y: npt.NDArray[np.float64],
         arr_xs: npt.NDArray[np.float64],
@@ -765,7 +765,7 @@ class SpencerFanoSolver:
         deltaen = float(self.deltaen)
         lastindex = len(self.engrid) - 2
 
-        for Z, ion_stage in self.get_all_ions():
+        for Z, ion_stage in self._get_all_ions():
             N_e_ion = 0.0
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
 
@@ -794,7 +794,7 @@ class SpencerFanoSolver:
             if (Z, ion_stage) not in self._ionisation_ions:
                 continue
 
-            for shell in self.get_ion_collion_rows(Z, ion_stage):
+            for shell in self._get_ion_collion_rows(Z, ion_stage):
                 ionpot_ev = float(shell["ionpot_ev"])
 
                 enlambda = min(e_max - energy_ev, energy_ev + ionpot_ev)
@@ -807,13 +807,13 @@ class SpencerFanoSolver:
                 # magnitude, depending on where the grid points happened to fall relative to ionpot_ev.
                 if enlambda > ionpot_ev:
                     arr_epsilon = np.linspace(
-                        ionpot_ev, enlambda, num=self.npts_subgrid(enlambda - ionpot_ev, J), dtype=np.float64
+                        ionpot_ev, enlambda, num=self._npts_subgrid(enlambda - ionpot_ev, J), dtype=np.float64
                     )
                     arr_e_p = energy_ev + arr_epsilon
                     # every node here lies between grid points, so y is interpolated and the cross section
                     # evaluated directly, the latter because it rises steeply from zero just above the
                     # ionisation threshold that starts this integral
-                    N_e_ion += self.integrate_shell_secondaries(
+                    N_e_ion += self._integrate_shell_secondaries(
                         arr_e_p=arr_e_p,
                         # asarray because np.interp is typed as returning a scalar for a scalar x
                         arr_y=np.asarray(np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)),
@@ -839,9 +839,9 @@ class SpencerFanoSolver:
                     stopindex = min(startindex + NCELLS_SECOND_INTEGRAL_SUBGRID, len(self.engrid) - 1)
                     en_upper_low = float(self.engrid[stopindex])
                     arr_e_p_low = np.linspace(
-                        en_lower2, en_upper_low, num=self.npts_subgrid(en_upper_low - en_lower2, J), dtype=np.float64
+                        en_lower2, en_upper_low, num=self._npts_subgrid(en_upper_low - en_lower2, J), dtype=np.float64
                     )
-                    N_e_ion += self.integrate_shell_secondaries(
+                    N_e_ion += self._integrate_shell_secondaries(
                         arr_e_p=arr_e_p_low,
                         arr_y=np.asarray(np.interp(arr_e_p_low, self.engrid, self.yvec, left=0.0, right=0.0)),
                         arr_xs=pynonthermal.collion.get_arxs_array_shell(arr_e_p_low, shell),
@@ -852,10 +852,10 @@ class SpencerFanoSolver:
                     # the rest is smooth on the scale of J, so y and the cross section come straight
                     # from the solution and the cache rather than being re-evaluated
                     if stopindex < len(self.engrid) - 1:
-                        N_e_ion += self.integrate_shell_secondaries(
+                        N_e_ion += self._integrate_shell_secondaries(
                             arr_e_p=self.engrid[stopindex:],
                             arr_y=self.yvec[stopindex:],
-                            arr_xs=self.get_shell_xs(shell)[stopindex:],
+                            arr_xs=self._get_shell_xs(shell)[stopindex:],
                             e_s=energy_ev,
                             ionpot_ev=ionpot_ev,
                             J=J,
@@ -904,7 +904,7 @@ class SpencerFanoSolver:
         self._frac_heating = frac_heating
         return frac_heating
 
-    def reset_channel_fractions(self) -> None:
+    def _reset_channel_fractions(self) -> None:
         # clear the per-ion accumulators, which analyse_ntspectrum() sums into
         self._analysed = False
         self._frac_ionisation_tot = 0.0
@@ -915,13 +915,13 @@ class SpencerFanoSolver:
         self._eff_ionpot = {}
 
     def reset_solution_analysis(self) -> None:
-        self.reset_channel_fractions()
+        self._reset_channel_fractions()
         self._frac_heating = None
 
     def analyse_ntspectrum(self) -> None:
-        self.require_solved()
+        self._require_solved()
         # keep any frac_heating already computed for this solution, since it only depends on yvec
-        self.reset_channel_fractions()
+        self._reset_channel_fractions()
 
         deltaen = self.deltaen
 
@@ -929,11 +929,11 @@ class SpencerFanoSolver:
             print(f"    n_e_nt: {self.get_n_e_nt():.2e} [/cm3]")
 
         n_ion_tot = self.get_n_ion_tot()
-        for Z, ion_stage in self.get_all_ions():
+        for Z, ion_stage in self._get_all_ions():
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
             X_ion = n_ion / n_ion_tot if n_ion_tot > 0.0 else 0.0
             # an ion added only for excitation has no ionisation shells in the matrix
-            collionrows = self.get_ion_collion_rows(Z, ion_stage) if (Z, ion_stage) in self._ionisation_ions else []
+            collionrows = self._get_ion_collion_rows(Z, ion_stage) if (Z, ion_stage) in self._ionisation_ions else []
 
             ionpot_valence = min((float(shell["ionpot_ev"]) for shell in collionrows), default=None)
 
@@ -949,7 +949,7 @@ class SpencerFanoSolver:
             self._frac_ionisation_ion[(Z, ion_stage)] = 0.0
             eta_over_ionpot_sum = 0.0
             for shell in collionrows:
-                ar_xs_array = self.get_shell_xs(shell)
+                ar_xs_array = self._get_shell_xs(shell)
 
                 frac_ionisation_shell = (
                     n_ion
@@ -1054,41 +1054,41 @@ class SpencerFanoSolver:
 
     def get_n_e_nt(self) -> float:
         """Get the number density of non-thermal electrons in cm^-3."""
-        self.require_solved()
+        self._require_solved()
         arr_velocity = CLIGHT * np.sqrt(get_betasq(self.engrid))  # cm/s
 
         return float(np.sum(self.yvec / arr_velocity) * self.deltaen)
 
     def get_frac_heating(self) -> float:
-        self.require_solved()
+        self._require_solved()
         if self._frac_heating is None:
             return self.calculate_frac_heating()
 
         return self._frac_heating
 
     def get_frac_excitation_tot(self) -> float:
-        self.require_solved()
+        self._require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
         return self._frac_excitation_tot
 
     def get_frac_ionisation_tot(self) -> float:
-        self.require_solved()
+        self._require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
         return self._frac_ionisation_tot
 
     def get_frac_ionisation_ion(self, Z: int, ion_stage: int) -> float:
-        self.require_solved()
+        self._require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
         return self._frac_ionisation_ion[(Z, ion_stage)]
 
     def get_eff_ionpot(self, Z: int, ion_stage: int) -> float:
-        self.require_solved()
+        self._require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
@@ -1099,7 +1099,7 @@ class SpencerFanoSolver:
 
         This scales with depositionratedensity_ev.
         """
-        self.require_solved()
+        self._require_solved()
         if not self._analysed:
             self.analyse_ntspectrum()
 
@@ -1111,7 +1111,7 @@ class SpencerFanoSolver:
         This is the integral of y(E) * sigma(E) dE in Kozma & Fransson equation 9, matching the
         convention of get_ionisation_ratecoeff(). It scales with depositionratedensity_ev.
         """
-        self.require_solved()
+        self._require_solved()
         _levelnumberdensity, xsvec, _epsilon_trans_ev = self.excitationlists[(Z, ion_stage)][transitionkey]
 
         return float(np.dot(xsvec, self.yvec) * self.deltaen)
@@ -1120,14 +1120,14 @@ class SpencerFanoSolver:
         return self.get_frac_heating() + self.get_frac_excitation_tot() + self.get_frac_ionisation_tot()
 
     def get_d_etaheating_by_d_en_vec(self) -> list[float]:
-        self.require_solved()
+        self._require_solved()
         return [
             self.electronlossfunction(self.engrid[i]) * self.yvec[i] / self.depositionratedensity_ev
             for i in range(len(self.engrid))
         ]
 
     def get_d_etaexcitation_by_d_en_vec(self) -> npt.NDArray[np.float64]:
-        self.require_solved()
+        self._require_solved()
         part_integrand = np.zeros(len(self.engrid))
 
         for Z, ion_stage in self.excitationlists:
@@ -1141,14 +1141,14 @@ class SpencerFanoSolver:
         return self.yvec * part_integrand
 
     def get_d_etaion_by_d_en_vec(self) -> npt.NDArray[np.float64]:
-        self.require_solved()
+        self._require_solved()
         part_integrand = np.zeros(len(self.engrid))
 
         for Z, ion_stage in self._ionisation_ions:
             n_ion = self.ionpopdict[(Z, ion_stage)]
 
-            for shell in self.get_ion_collion_rows(Z, ion_stage):
-                xsvec = self.get_shell_xs(shell)
+            for shell in self._get_ion_collion_rows(Z, ion_stage):
+                xsvec = self._get_shell_xs(shell)
 
                 part_integrand += n_ion * shell["ionpot_ev"] * xsvec / self.depositionratedensity_ev
 
@@ -1161,7 +1161,7 @@ class SpencerFanoSolver:
         outputfilename: Path | str | None = None,
         axis: mplax.Axes | None = None,
     ) -> None:
-        self.require_solved()
+        self._require_solved()
         fs = 12
         fig = None
         if axis is None:
@@ -1204,7 +1204,7 @@ class SpencerFanoSolver:
     def plot_channels(
         self, outputfilename: Path | str | None = None, axis: mplax.Axes | None = None, xscalelog: bool = False
     ) -> None:
-        self.require_solved()
+        self._require_solved()
         fs = 12
         fig = None
         if axis is None:

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -538,15 +538,16 @@ def _reference_excitation_fill(
     xs_vec: npt.NDArray[np.float64],
     epsilon_trans_ev: float,
 ) -> npt.NDArray[np.float64]:
-    # the row-by-row construction of one transition's matrix contribution that predates the
-    # strided band fill, kept verbatim as the reference the fast path must reproduce exactly
+    # a standalone copy of the row-by-row fill (the production _excitation_fill_rows), kept
+    # independent so that a regression in the production helper or the banded fast path that
+    # calls it cannot hide here
     engrid = sf.engrid
     npts = len(engrid)
     deltaen = sf.deltaen
     contribution = np.zeros((npts, npts))
     vec = levelnumberdensity * deltaen * xs_vec
     xsstartindex = sf.get_energyindex_lteq(en_ev=epsilon_trans_ev)
-    stopindices = np.clip(np.floor((engrid + epsilon_trans_ev - engrid[0]) / deltaen).astype(np.int64), 0, npts - 1)
+    stopindices = np.array([sf.get_energyindex_lteq(float(en + epsilon_trans_ev)) for en in engrid])
     delta_en_actuals = np.minimum(engrid + epsilon_trans_ev - engrid[stopindices], deltaen)
     for i in range(npts):
         stopindex = stopindices[i]
@@ -563,8 +564,12 @@ def test_excitation_band_fill_matches_rowwise() -> None:
     # truncated by the excitation threshold and the rows clipped at the top of the grid.
     npts = 157
     emin, emax = 1.0, 300.0
-    deltaen = (emax - emin) / (npts - 1)
     rng = np.random.default_rng(42)
+    # the grid spacing must come from the solver's np.linspace grid: recomputing it as
+    # (emax - emin) / (npts - 1) differs by one ulp, enough to change the band width by one
+    # for the grid-aligned cases below
+    with pynonthermal.SpencerFanoSolver(emin_ev=emin, emax_ev=emax, npts=npts) as sf_grid:
+        deltaen = sf_grid.deltaen
     epsilons = [
         0.5 * deltaen,  # narrower than one grid cell: band width zero, partial bins only
         5 * deltaen,  # an exact multiple of the grid spacing
@@ -592,7 +597,7 @@ def _reference_ionisation_fill(
     deltaen = sf.deltaen
     ionpot_ev = float(shell["ionpot_ev"])
     J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
-    ar_xs_array = pynonthermal.collion.get_arxs_array_shell(engrid, shell)
+    ar_xs_array = sf._get_shell_xs(shell)
     xsstartindex = 0 if ionpot_ev <= engrid[0] else sf.get_energyindex_gteq(en_ev=ionpot_ev)
     atan_epsilon = np.arctan((engrid - ionpot_ev) / 2.0 / J)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -636,9 +641,7 @@ def test_ionisation_fill_matches_masked_reference() -> None:
             n_ion = 1e5
             sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
             expected = np.zeros((npts, npts))
-            # same shell rows in the same order as add_ionisation iterates them
-            shells = sf.dfcollion.filter((pl.col("Z") == Z) & (pl.col("ion_stage") == ion_stage)).to_dicts()
-            for shell in shells:
+            for shell in sf._get_ion_collion_rows(Z, ion_stage):
                 expected += _reference_ionisation_fill(sf, n_ion, shell)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {Z=} {ion_stage=}"
 

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -585,6 +585,30 @@ def test_excitation_band_fill_matches_rowwise() -> None:
             expected = _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {epsilon_trans_ev=}"
 
+    # transitions are summed per band offset in a shared buffer before being applied to the
+    # matrix. Buffer cells accumulate transitions in the order they were added, so a sequence
+    # of buffered bands flushed onto a zero matrix is bit-identical to row-by-row fills
+    # applied in the same order.
+    with pynonthermal.SpencerFanoSolver(emin_ev=200.0, emax_ev=300.0, npts=npts) as sf:
+        expected = np.zeros((npts, npts))
+        for epsilon_trans_ev in (5.0, 13.3, 5.0):
+            xs_vec = rng.random(npts) * 1e-16
+            sf.add_excitation(8, 2, levelnumberdensity=1e5, xs_vec=xs_vec, epsilon_trans_ev=epsilon_trans_ev)
+            expected += _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
+        assert sf.sfmatrix.tobytes() == expected.tobytes()
+
+    # a band too wide for the buffer is written to the matrix directly after flushing it, so
+    # entries touched both before and after the flush see their transitions summed in a
+    # different (but same-order) association than sequential row fills: equal to within one
+    # rounding, not bitwise
+    with pynonthermal.SpencerFanoSolver(emin_ev=200.0, emax_ev=300.0, npts=npts) as sf:
+        expected = np.zeros((npts, npts))
+        for epsilon_trans_ev in (5.0, 250.0, 5.0, 13.3):
+            xs_vec = rng.random(npts) * 1e-16
+            sf.add_excitation(8, 2, levelnumberdensity=1e5, xs_vec=xs_vec, epsilon_trans_ev=epsilon_trans_ev)
+            expected += _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
+        assert np.allclose(sf.sfmatrix, expected, rtol=1e-13, atol=0.0)
+
 
 def _reference_ionisation_fill(
     sf: pynonthermal.SpencerFanoSolver, n_ion: float, shell: dict[str, int | float]

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -596,7 +596,7 @@ def _reference_ionisation_fill(
     deltaen = sf.deltaen
     ionpot_ev = float(shell["ionpot_ev"])
     J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
-    ar_xs_array = sf._get_shell_xs(shell)
+    ar_xs_array = sf._get_shell_xs(shell)  # pyright: ignore[reportPrivateUsage]
     xsstartindex = 0 if ionpot_ev <= engrid[0] else sf.get_energyindex_gteq(en_ev=ionpot_ev)
     atan_epsilon = np.arctan((engrid - ionpot_ev) / 2.0 / J)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -654,7 +654,7 @@ def test_ionisation_fill_matches_masked_reference() -> None:
             n_ion = 1e5
             sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
             expected = np.zeros((npts, npts))
-            for shell in sf._get_ion_collion_rows(Z, ion_stage):
+            for shell in sf._get_ion_collion_rows(Z, ion_stage):  # pyright: ignore[reportPrivateUsage]
                 expected += _reference_ionisation_fill(sf, n_ion, shell)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {Z=} {ion_stage=}"
 

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -530,3 +530,142 @@ def test_lossfunction_plasma_energy_guard() -> None:
     arr_loss = [pynonthermal.electronlossfunction(en_ev, 1e8) for en_ev in (1.0, 5.0, 14.0, 100.0, 3000.0)]
     assert all(loss > 0.0 for loss in arr_loss)
     assert all(b < a for a, b in itertools.pairwise(arr_loss))
+
+
+def _reference_excitation_fill(
+    sf: pynonthermal.SpencerFanoSolver,
+    levelnumberdensity: float,
+    xs_vec: npt.NDArray[np.float64],
+    epsilon_trans_ev: float,
+) -> npt.NDArray[np.float64]:
+    # the row-by-row construction of one transition's matrix contribution that predates the
+    # strided band fill, kept verbatim as the reference the fast path must reproduce exactly
+    engrid = sf.engrid
+    npts = len(engrid)
+    deltaen = sf.deltaen
+    contribution = np.zeros((npts, npts))
+    vec = levelnumberdensity * deltaen * xs_vec
+    xsstartindex = sf.get_energyindex_lteq(en_ev=epsilon_trans_ev)
+    stopindices = np.clip(np.floor((engrid + epsilon_trans_ev - engrid[0]) / deltaen).astype(np.int64), 0, npts - 1)
+    delta_en_actuals = np.minimum(engrid + epsilon_trans_ev - engrid[stopindices], deltaen)
+    for i in range(npts):
+        stopindex = stopindices[i]
+        startindex = max(i, xsstartindex)
+        contribution[i, startindex:stopindex] += vec[startindex:stopindex]
+        contribution[i, stopindex] += vec[stopindex] * delta_en_actuals[i] / deltaen
+    return contribution
+
+
+def test_excitation_band_fill_matches_rowwise() -> None:
+    # add_excitation writes each transition as one strided band plus a partial-bin diagonal
+    # (every row repeats the same vec[j] values over the overlap of its window with the next
+    # row's). The result must be bit-identical to the row-by-row fill, including the rows
+    # truncated by the excitation threshold and the rows clipped at the top of the grid.
+    npts = 157
+    emin, emax = 1.0, 300.0
+    deltaen = (emax - emin) / (npts - 1)
+    rng = np.random.default_rng(42)
+    epsilons = [
+        0.5 * deltaen,  # narrower than one grid cell: band width zero, partial bins only
+        5 * deltaen,  # an exact multiple of the grid spacing
+        13.3,  # a typical transition energy, not aligned with the grid
+        299.0,  # band nearly as wide as the whole grid
+        emax,  # at the top of the grid: every row's window is clipped
+    ]
+    for epsilon_trans_ev in epsilons:
+        with pynonthermal.SpencerFanoSolver(emin_ev=emin, emax_ev=emax, npts=npts) as sf:
+            # nonzero cross sections below threshold too: the caller is not required to zero them,
+            # and the partial-bin term is written for every row
+            xs_vec = rng.random(npts) * 1e-16
+            sf.add_excitation(8, 2, levelnumberdensity=1e5, xs_vec=xs_vec, epsilon_trans_ev=epsilon_trans_ev)
+            expected = _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
+            assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {epsilon_trans_ev=}"
+
+
+def _reference_ionisation_fill(
+    sf: pynonthermal.SpencerFanoSolver, n_ion: float, shell: dict[str, int | float]
+) -> npt.NDArray[np.float64]:
+    # the masked full-tail construction of one shell's matrix contribution that predates the
+    # forward-only cut pointers, kept verbatim as the reference the slice fill must reproduce
+    engrid = sf.engrid
+    npts = len(engrid)
+    deltaen = sf.deltaen
+    ionpot_ev = float(shell["ionpot_ev"])
+    J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
+    ar_xs_array = pynonthermal.collion.get_arxs_array_shell(engrid, shell)
+    xsstartindex = 0 if ionpot_ev <= engrid[0] else sf.get_energyindex_gteq(en_ev=ionpot_ev)
+    atan_epsilon = np.arctan((engrid - ionpot_ev) / 2.0 / J)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        prefactors = np.divide(
+            n_ion * ar_xs_array * deltaen, atan_epsilon, out=np.zeros(npts), where=atan_epsilon != 0.0
+        )
+    epsilon_uppers = np.minimum((engrid + ionpot_ev) / 2, engrid)
+    int_eps_uppers = np.arctan((epsilon_uppers - ionpot_ev) / J)
+    epsilon_lowers1 = np.maximum(engrid - engrid[0], ionpot_ev)
+    int_eps_lowers1 = np.arctan((epsilon_lowers1 - ionpot_ev) / J)
+    contribution = np.zeros((npts, npts))
+    for i, en in enumerate(engrid):
+        jstart = max(i, xsstartindex)
+        contribution[i, jstart:] += np.where(
+            epsilon_lowers1[jstart - i : npts - i] <= epsilon_uppers[jstart:],
+            prefactors[jstart:] * (int_eps_uppers[jstart:] - int_eps_lowers1[jstart - i : npts - i]),
+            0.0,
+        )
+        if 2 * en + ionpot_ev < engrid[-1] + deltaen:
+            secondintegralstartindex = sf.get_energyindex_lteq(float(2 * en + ionpot_ev))
+            epsilon_lower2 = en + ionpot_ev
+            int_eps_lower2 = math.atan((epsilon_lower2 - ionpot_ev) / J)
+            contribution[i, secondintegralstartindex:] -= np.where(
+                epsilon_lower2 <= epsilon_uppers[secondintegralstartindex:],
+                prefactors[secondintegralstartindex:] * (int_eps_uppers[secondintegralstartindex:] - int_eps_lower2),
+                0.0,
+            )
+    return contribution
+
+
+def test_ionisation_fill_matches_masked_reference() -> None:
+    # _add_ionisation_shell writes only each row's non-empty integral range, located by
+    # forward-only cut pointers that evaluate the same comparisons the per-row np.where masks
+    # used. The resulting matrix must be bit-identical to the masked full-tail construction.
+    for emin, emax, npts, Z, ion_stage in [
+        (1.0, 300.0, 193, 8, 2),
+        (7.9, 16000.0, 217, 26, 2),  # emin well above 1 eV and a heavy ion with many shells
+        (1.0, 3000.0, 149, 2, 1),  # helium: J takes the Opal et al. 1971 special-case value
+    ]:
+        with pynonthermal.SpencerFanoSolver(emin_ev=emin, emax_ev=emax, npts=npts) as sf:
+            n_ion = 1e5
+            sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
+            expected = np.zeros((npts, npts))
+            # same shell rows in the same order as add_ionisation iterates them
+            shells = sf.dfcollion.filter((pl.col("Z") == Z) & (pl.col("ion_stage") == ion_stage)).to_dicts()
+            for shell in shells:
+                expected += _reference_ionisation_fill(sf, n_ion, shell)
+            assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {Z=} {ion_stage=}"
+
+
+def test_solve_upper_triangular_diag_add() -> None:
+    # solve() passes the free-electron loss function as a separate diagonal vector instead of
+    # copying the whole matrix to add it, so the diag_add path must reproduce the added-in-place
+    # result exactly
+    rng = np.random.default_rng(7)
+    n = 40
+    a = np.triu(rng.random((n, n))) + np.diag(np.full(n, 2.0))
+    b = rng.random(n)
+    d = rng.random(n)
+    expected = spencerfano.solve_upper_triangular(a + np.diag(d), b)
+    assert np.array_equal(spencerfano.solve_upper_triangular(a, b, diag_add=d), expected)
+
+    # the singularity check applies to the summed diagonal: a zero on the matrix diagonal is
+    # fine when diag_add makes the sum non-zero...
+    a_zerodiag = a.copy()
+    a_zerodiag[3, 3] = 0.0
+    assert np.isfinite(spencerfano.solve_upper_triangular(a_zerodiag, b, diag_add=d)).all()
+
+    # ...and a cancellation to exactly zero is singular
+    d_cancel = d.copy()
+    d_cancel[3] = -a[3, 3]
+    with pytest.raises(np.linalg.LinAlgError, match="singular"):
+        spencerfano.solve_upper_triangular(a, b, diag_add=d_cancel)
+
+    with pytest.raises(ValueError, match="finite"):
+        spencerfano.solve_upper_triangular(a, b, diag_add=np.array([math.nan] + [0.0] * (n - 1)))

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -627,6 +627,20 @@ def _reference_ionisation_fill(
     return contribution
 
 
+def test_ltepop_excitation_grouped_fill() -> None:
+    # add_ion_ltepopexcitation writes the matrix once per distinct band width, with the vectors
+    # of same-width transitions pre-summed. Rebuilding from the stored per-transition data must
+    # agree to within summation-order rounding.
+    npts = 400
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=npts) as sf:
+        sf.add_ion_ltepopexcitation(2, 1, n_ion=1.0, use_collstrengths=False)
+        assert len(sf.excitationlists[(2, 1)]) > 100  # the grouping must actually see many transitions
+        expected = np.zeros((npts, npts))
+        for levelnumberdensity, xs_vec, epsilon_trans_ev in sf.excitationlists[(2, 1)].values():
+            expected += _reference_excitation_fill(sf, levelnumberdensity, xs_vec, epsilon_trans_ev)
+        assert np.allclose(sf.sfmatrix, expected, rtol=1e-12, atol=0.0)
+
+
 def test_ionisation_fill_matches_masked_reference() -> None:
     # _add_ionisation_shell writes only each row's non-empty integral range, located by
     # forward-only cut pointers that evaluate the same comparisons the per-row np.where masks

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -538,46 +538,45 @@ def _reference_excitation_fill(
     xs_vec: npt.NDArray[np.float64],
     epsilon_trans_ev: float,
 ) -> npt.NDArray[np.float64]:
-    # a standalone copy of the row-by-row fill (the production _excitation_fill_rows), kept
-    # independent so that a regression in the production helper or the banded fast path that
-    # calls it cannot hide here
+    # straightforward row-by-row construction of one transition's contribution: row i covers k
+    # full-width bins from max(i, threshold index) plus a partial final bin of weight frac,
+    # truncated at the top of the grid where every remaining bin is full width. Kept independent
+    # of the production code so that a regression in the banded fill cannot hide here.
     engrid = sf.engrid
     npts = len(engrid)
     deltaen = sf.deltaen
     contribution = np.zeros((npts, npts))
     vec = levelnumberdensity * deltaen * xs_vec
     xsstartindex = sf.get_energyindex_lteq(en_ev=epsilon_trans_ev)
-    stopindices = np.array([sf.get_energyindex_lteq(float(en + epsilon_trans_ev)) for en in engrid])
-    delta_en_actuals = np.minimum(engrid + epsilon_trans_ev - engrid[stopindices], deltaen)
+    k = int(epsilon_trans_ev / deltaen)
+    frac = epsilon_trans_ev / deltaen - k
     for i in range(npts):
-        stopindex = stopindices[i]
         startindex = max(i, xsstartindex)
-        contribution[i, startindex:stopindex] += vec[startindex:stopindex]
-        contribution[i, stopindex] += vec[stopindex] * delta_en_actuals[i] / deltaen
+        if i + k < npts:
+            contribution[i, startindex : i + k] += vec[startindex : i + k]
+            contribution[i, i + k] += vec[i + k] * frac
+        else:
+            contribution[i, startindex:] += vec[startindex:]
     return contribution
 
 
 def test_excitation_band_fill_matches_rowwise() -> None:
-    # add_excitation writes each transition as one strided band plus a partial-bin diagonal
+    # add_excitation writes each transition as one windowed band plus a partial-bin diagonal
     # (every row repeats the same vec[j] values over the overlap of its window with the next
     # row's). The result must be bit-identical to the row-by-row fill, including the rows
     # truncated by the excitation threshold and the rows clipped at the top of the grid.
-    npts = 157
-    emin, emax = 1.0, 300.0
     rng = np.random.default_rng(42)
-    # the grid spacing must come from the solver's np.linspace grid: recomputing it as
-    # (emax - emin) / (npts - 1) differs by one ulp, enough to change the band width by one
-    # for the grid-aligned cases below
-    with pynonthermal.SpencerFanoSolver(emin_ev=emin, emax_ev=emax, npts=npts) as sf_grid:
-        deltaen = sf_grid.deltaen
-    epsilons = [
-        0.5 * deltaen,  # narrower than one grid cell: band width zero, partial bins only
-        5 * deltaen,  # an exact multiple of the grid spacing
-        13.3,  # a typical transition energy, not aligned with the grid
-        299.0,  # band nearly as wide as the whole grid
-        emax,  # at the top of the grid: every row's window is clipped
+    npts = 157
+    deltaen = (300.0 - 1.0) / (npts - 1)  # approximate spacing, only used to place the cases below
+    cases = [
+        (1.0, 300.0, 0.5 * deltaen),  # narrower than one grid cell: band width zero, partial bins only
+        (1.0, 300.0, 5 * deltaen),  # within rounding of an exact multiple of the grid spacing
+        (1.0, 300.0, 13.3),  # a typical transition energy, not aligned with the grid
+        (1.0, 300.0, 299.0),  # band nearly as wide as the whole grid
+        (1.0, 300.0, 300.0),  # at the top of the grid: every row's window is clipped
+        (200.0, 300.0, 250.0),  # band wider than the whole grid: every row is clipped and truncated
     ]
-    for epsilon_trans_ev in epsilons:
+    for emin, emax, epsilon_trans_ev in cases:
         with pynonthermal.SpencerFanoSolver(emin_ev=emin, emax_ev=emax, npts=npts) as sf:
             # nonzero cross sections below threshold too: the caller is not required to zero them,
             # and the partial-bin term is written for every row

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -532,7 +532,7 @@ def test_lossfunction_plasma_energy_guard() -> None:
     assert all(b < a for a, b in itertools.pairwise(arr_loss))
 
 
-def reference_excitation_fill(
+def _reference_excitation_fill(
     sf: pynonthermal.SpencerFanoSolver,
     levelnumberdensity: float,
     xs_vec: npt.NDArray[np.float64],
@@ -582,11 +582,11 @@ def test_excitation_band_fill_matches_rowwise() -> None:
             # and the partial-bin term is written for every row
             xs_vec = rng.random(npts) * 1e-16
             sf.add_excitation(8, 2, levelnumberdensity=1e5, xs_vec=xs_vec, epsilon_trans_ev=epsilon_trans_ev)
-            expected = reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
+            expected = _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {epsilon_trans_ev=}"
 
 
-def reference_ionisation_fill(
+def _reference_ionisation_fill(
     sf: pynonthermal.SpencerFanoSolver, n_ion: float, shell: dict[str, int | float]
 ) -> npt.NDArray[np.float64]:
     # the masked full-tail construction of one shell's matrix contribution that predates the
@@ -596,7 +596,7 @@ def reference_ionisation_fill(
     deltaen = sf.deltaen
     ionpot_ev = float(shell["ionpot_ev"])
     J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
-    ar_xs_array = sf.get_shell_xs(shell)
+    ar_xs_array = sf._get_shell_xs(shell)
     xsstartindex = 0 if ionpot_ev <= engrid[0] else sf.get_energyindex_gteq(en_ev=ionpot_ev)
     atan_epsilon = np.arctan((engrid - ionpot_ev) / 2.0 / J)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -628,7 +628,7 @@ def reference_ionisation_fill(
 
 
 def test_ionisation_fill_matches_masked_reference() -> None:
-    # add_ionisation_shell writes only each row's non-empty integral range, located by
+    # _add_ionisation_shell writes only each row's non-empty integral range, located by
     # forward-only cut pointers that evaluate the same comparisons the per-row np.where masks
     # used. The resulting matrix must be bit-identical to the masked full-tail construction.
     for emin, emax, npts, Z, ion_stage in [
@@ -640,8 +640,8 @@ def test_ionisation_fill_matches_masked_reference() -> None:
             n_ion = 1e5
             sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
             expected = np.zeros((npts, npts))
-            for shell in sf.get_ion_collion_rows(Z, ion_stage):
-                expected += reference_ionisation_fill(sf, n_ion, shell)
+            for shell in sf._get_ion_collion_rows(Z, ion_stage):
+                expected += _reference_ionisation_fill(sf, n_ion, shell)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {Z=} {ion_stage=}"
 
 

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -585,30 +585,6 @@ def test_excitation_band_fill_matches_rowwise() -> None:
             expected = _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {epsilon_trans_ev=}"
 
-    # transitions are summed per band offset in a shared buffer before being applied to the
-    # matrix. Buffer cells accumulate transitions in the order they were added, so a sequence
-    # of buffered bands flushed onto a zero matrix is bit-identical to row-by-row fills
-    # applied in the same order.
-    with pynonthermal.SpencerFanoSolver(emin_ev=200.0, emax_ev=300.0, npts=npts) as sf:
-        expected = np.zeros((npts, npts))
-        for epsilon_trans_ev in (5.0, 13.3, 5.0):
-            xs_vec = rng.random(npts) * 1e-16
-            sf.add_excitation(8, 2, levelnumberdensity=1e5, xs_vec=xs_vec, epsilon_trans_ev=epsilon_trans_ev)
-            expected += _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
-        assert sf.sfmatrix.tobytes() == expected.tobytes()
-
-    # a band too wide for the buffer is written to the matrix directly after flushing it, so
-    # entries touched both before and after the flush see their transitions summed in a
-    # different (but same-order) association than sequential row fills: equal to within one
-    # rounding, not bitwise
-    with pynonthermal.SpencerFanoSolver(emin_ev=200.0, emax_ev=300.0, npts=npts) as sf:
-        expected = np.zeros((npts, npts))
-        for epsilon_trans_ev in (5.0, 250.0, 5.0, 13.3):
-            xs_vec = rng.random(npts) * 1e-16
-            sf.add_excitation(8, 2, levelnumberdensity=1e5, xs_vec=xs_vec, epsilon_trans_ev=epsilon_trans_ev)
-            expected += _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
-        assert np.allclose(sf.sfmatrix, expected, rtol=1e-13, atol=0.0)
-
 
 def _reference_ionisation_fill(
     sf: pynonthermal.SpencerFanoSolver, n_ion: float, shell: dict[str, int | float]

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -532,7 +532,7 @@ def test_lossfunction_plasma_energy_guard() -> None:
     assert all(b < a for a, b in itertools.pairwise(arr_loss))
 
 
-def _reference_excitation_fill(
+def reference_excitation_fill(
     sf: pynonthermal.SpencerFanoSolver,
     levelnumberdensity: float,
     xs_vec: npt.NDArray[np.float64],
@@ -582,11 +582,11 @@ def test_excitation_band_fill_matches_rowwise() -> None:
             # and the partial-bin term is written for every row
             xs_vec = rng.random(npts) * 1e-16
             sf.add_excitation(8, 2, levelnumberdensity=1e5, xs_vec=xs_vec, epsilon_trans_ev=epsilon_trans_ev)
-            expected = _reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
+            expected = reference_excitation_fill(sf, 1e5, xs_vec, epsilon_trans_ev)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {epsilon_trans_ev=}"
 
 
-def _reference_ionisation_fill(
+def reference_ionisation_fill(
     sf: pynonthermal.SpencerFanoSolver, n_ion: float, shell: dict[str, int | float]
 ) -> npt.NDArray[np.float64]:
     # the masked full-tail construction of one shell's matrix contribution that predates the
@@ -596,7 +596,7 @@ def _reference_ionisation_fill(
     deltaen = sf.deltaen
     ionpot_ev = float(shell["ionpot_ev"])
     J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
-    ar_xs_array = sf._get_shell_xs(shell)
+    ar_xs_array = sf.get_shell_xs(shell)
     xsstartindex = 0 if ionpot_ev <= engrid[0] else sf.get_energyindex_gteq(en_ev=ionpot_ev)
     atan_epsilon = np.arctan((engrid - ionpot_ev) / 2.0 / J)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -628,7 +628,7 @@ def _reference_ionisation_fill(
 
 
 def test_ionisation_fill_matches_masked_reference() -> None:
-    # _add_ionisation_shell writes only each row's non-empty integral range, located by
+    # add_ionisation_shell writes only each row's non-empty integral range, located by
     # forward-only cut pointers that evaluate the same comparisons the per-row np.where masks
     # used. The resulting matrix must be bit-identical to the masked full-tail construction.
     for emin, emax, npts, Z, ion_stage in [
@@ -640,8 +640,8 @@ def test_ionisation_fill_matches_masked_reference() -> None:
             n_ion = 1e5
             sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
             expected = np.zeros((npts, npts))
-            for shell in sf._get_ion_collion_rows(Z, ion_stage):
-                expected += _reference_ionisation_fill(sf, n_ion, shell)
+            for shell in sf.get_ion_collion_rows(Z, ion_stage):
+                expected += reference_ionisation_fill(sf, n_ion, shell)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {Z=} {ion_stage=}"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ unfixable = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"pynonthermal/tests/*" = ["SLF001"] # tests may use private members to compare against production inputs
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ unfixable = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
-"pynonthermal/tests/*" = ["SLF001"] # tests may use private members to compare against production inputs
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
## Summary
This PR optimizes the Spencer-Fano solver's matrix construction for excitation and ionization processes, and adds comprehensive regression tests to ensure correctness of the optimized implementations.

## Key Changes

### Performance Optimizations
- **Excitation band fill**: Refactored `add_excitation()` to use vectorized band operations instead of row-by-row construction. Extracted `_store_excitation()` and `_add_excitation_band()` methods to enable grouping transitions with identical band widths and writing them once with pre-summed vectors, significantly reducing matrix write operations.
- **Ionization fill**: Optimized `_add_ionisation_shell()` to use forward-only cut pointers instead of per-row `np.where` masks. The pointers track contiguous non-empty column ranges using the same comparisons the masks would make, eliminating redundant evaluations.
- **Solver diagonal handling**: Modified `solve_upper_triangular()` to accept an optional `diag_add` parameter, allowing the free-electron loss function to be applied as a separate diagonal vector rather than copying the entire matrix just to modify its diagonal.

### Regression Tests
- **`test_excitation_band_fill_matches_rowwise()`**: Validates that the optimized banded fill produces bit-identical results to a straightforward row-by-row reference implementation across six edge cases (narrow bands, grid-aligned transitions, clipped windows, etc.).
- **`test_ltepop_excitation_grouped_fill()`**: Ensures that grouping transitions by band width and pre-summing their vectors produces results matching the sum of individual transition contributions.
- **`test_ionisation_fill_matches_masked_reference()`**: Verifies that the forward-only cut pointer optimization produces bit-identical results to the original masked full-tail construction across multiple ion configurations.
- **`test_solve_upper_triangular_diag_add()`**: Confirms that the `diag_add` parameter produces identical solutions to the traditional approach of adding the diagonal in-place, including singularity detection.

### Code Quality
- Updated `pyproject.toml` to allow tests to access private members (SLF001) for regression testing purposes.

## Implementation Details
- The excitation band optimization exploits the uniform grid to express all rows' geometry identically, enabling a single windowed addition plus one matrix diagonal operation instead of per-row loops.
- The ionization optimization uses a forward-only pointer that only moves right as energy increases, avoiding redundant comparisons while maintaining correctness.
- All optimizations maintain numerical equivalence with their reference implementations to within floating-point precision.

https://claude.ai/code/session_01BvLAcxvd5Mn2GtyQW5YKmS