### PR TITLE
Upload test coverage from the pytest workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,7 @@
 ---
 name: Benchmark with CodSpeed
-
+permissions:
+    contents: read
 on:
     push:
         branches:

--- a/.github/workflows/deploypypi.yml
+++ b/.github/workflows/deploypypi.yml
@@ -1,6 +1,7 @@
 ---
 name: Build and deploy to PyPI/testPyPI
-
+permissions:
+    contents: read
 on:
     push:
     merge_group:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -127,3 +127,6 @@ jobs:
                   file: coverage.xml
                   language: Python
                   label: code-coverage-agent
+                  # the upload returns 404 until code coverage is enabled for the repository, which
+                  # should not fail an otherwise passing test run
+                  fail-on-error: false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -91,3 +91,39 @@ jobs:
 
             - name: Report coverage
               run: uv run -- python3 -m coverage report
+
+            - name: Upload coverage artifact
+              if: matrix.python-version == '3.14' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: coverage-report-python
+                  path: coverage.xml
+
+    upload-coverage-python:
+        needs: pytest
+        if: ${{ !cancelled() && needs.pytest.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name
+            == github.repository) }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            code-quality: write
+            pull-requests: read
+        steps:
+            - name: Download coverage artifact
+              uses: actions/download-artifact@v8
+              with:
+                  name: coverage-report-python
+
+            - name: Check for a pull request associated with this commit
+              id: haspr
+              if: github.ref != 'refs/heads/main'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: echo "found=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq 'length > 0')" >> "$GITHUB_OUTPUT"
+
+            - uses: actions/upload-code-coverage@v1
+              if: github.ref == 'refs/heads/main' || steps.haspr.outputs.found == 'true'
+              with:
+                  file: coverage.xml
+                  language: Python
+                  label: code-coverage-agent

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,7 @@
 ---
 name: Test and lint
+permissions:
+    contents: read
 on:
     push:
     merge_group:


### PR DESCRIPTION
The pytest jobs already produce `coverage.xml` (`pytest --cov --cov-report=xml`) and print a terminal report, but the file was never uploaded. This mirrors the [artistools test workflow](https://github.com/artis-mcrt/artistools/blob/main/.github/workflows/pytest.yml):

- The Python 3.14 matrix job uploads `coverage.xml` as a `coverage-report-python` artifact (skipped for fork pull requests).
- A follow-up `upload-coverage-python` job downloads the artifact and publishes it with `actions/upload-code-coverage@v1` (`code-quality: write` permission), for pushes to `main` and for commits that have an associated pull request; on other branch pushes the upload step is skipped.
- The upload step sets `fail-on-error: false`, so a rejected upload is a warning rather than a red test run.

The fork-PR guard conditions are currently inert because this workflow's `pull_request` trigger is commented out, but they are kept verbatim from artistools so they are already correct if that trigger is re-enabled.

### Enabling the upload

The first run of this workflow showed the machinery working end to end — the artifact was produced, this pull request was detected, and the 52 KB `coverage.xml` was submitted — but GitHub's coverage API answered **HTTP 404**, which is what it returns until [code coverage is enabled for the repository](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage). Enabling it in the repository settings is what makes the reports actually appear; until then the job stays green and logs a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvLAcxvd5Mn2GtyQW5YKmS