### PR TITLE
Add a heating_only_approximation option to SpencerFanoSolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ sf = pynonthermal.SpencerFanoSolver(emin_ev=1.0, emax_ev=3000.0, npts=4096, verb
 - `npts`: number of energy grid points. More points give better accuracy at the cost of memory and time; check `get_frac_sum()` after solving.
 - `verbose`: print details of the setup, each added channel, and a per-ion, per-shell breakdown during analysis.
 - `use_ar1985`: use the original Arnaud & Rothenflug (1985) ionisation cross sections (see [Cross-section datasets](#cross-section-datasets)).
+- `heating_only_approximation`: remove the excitation and ionisation loss terms from the matrix and solve with the heating loss only. The solver still calculates the excitation and ionisation rates from this approximate solution, so the channel fractions do not sum to one.
 
 The grid is available as `sf.engrid` (a NumPy array), which is needed if you supply [custom excitation cross sections](#advanced-usage-custom-excitation-cross-sections).
 

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -156,6 +156,12 @@ class SpencerFanoSolver:
     (KF92 equation 12, summed over shells in analyse_ntspectrum()) with rate coefficients
     from get_ionisation_ratecoeff() (KF92 equation 13). calculate_N_e() evaluates N(E) of
     KF92 equation 11, the rate at which electrons appear below the solved grid.
+
+    If heating_only_approximation is True, the solver removes the excitation and ionisation
+    loss terms from the matrix and keeps only the heating loss. The solver still stores the
+    excitation transitions and the ionisation cross sections, and it calculates the channel
+    fractions and rate coefficients from the heating-only solution. The channel fractions
+    then do not sum to one.
     """
 
     _solved: bool
@@ -174,6 +180,7 @@ class SpencerFanoSolver:
     ionpopdict: dict[tuple[int, int], float]
     excitationlists: dict[tuple[int, int], dict[t.Any, tuple[float, npt.NDArray[np.float64], float]]]
     verbose: bool
+    heating_only_approximation: bool
     _n_e: float | None
     _n_e_override: float | None
     engrid: npt.NDArray[np.float64]
@@ -192,8 +199,13 @@ class SpencerFanoSolver:
         npts: int = 4096,
         verbose: bool = False,
         use_ar1985: bool = False,
+        heating_only_approximation: bool = False,
     ) -> None:
-        """Make a solver with a uniform linear energy grid and the given options."""
+        """Make a solver with a uniform linear energy grid and the given options.
+
+        If heating_only_approximation is True, the solver removes the excitation and
+        ionisation loss terms from the matrix and keeps only the heating loss.
+        """
         if npts < 2:
             msg = f"npts must be at least 2 to define an energy grid spacing but is {npts}"
             raise ValueError(msg)
@@ -220,6 +232,7 @@ class SpencerFanoSolver:
         self.excitationlists = {}
 
         self.verbose = verbose
+        self.heating_only_approximation = heating_only_approximation
         self.engrid = np.linspace(emin_ev, emax_ev, num=npts, endpoint=True, dtype=float)
         self.deltaen = self.engrid[1] - self.engrid[0]
 
@@ -418,6 +431,9 @@ class SpencerFanoSolver:
         # contribution is one windowed addition plus one matrix diagonal, with a row loop only
         # for the clipped rows. The band values add linearly, so vec and fracvec may also hold
         # the pre-summed contributions of many transitions that share the same k.
+        if self.heating_only_approximation:
+            # keep the stored transitions but leave the excitation loss out of the matrix
+            return
         npts = len(self.engrid)
         bandstop = max(npts - k, 0)  # rows from here on have their window clipped at the top of the grid
         # sfmatrix is C-contiguous (np.zeros), so element (i, i + d) sits at flat index
@@ -569,6 +585,9 @@ class SpencerFanoSolver:
                         transition["epsilon_trans_ev"],
                         transitionkey=(transition["lower"], transition["upper"]),
                     )
+                    if self.heating_only_approximation:
+                        # the matrix takes no excitation band, so skip the band accumulation
+                        continue
                     if k not in groups:
                         groups[k] = (np.zeros(npts), np.zeros(npts))
                     groupvec, groupfracvec = groups[k]
@@ -591,6 +610,10 @@ class SpencerFanoSolver:
         # distribution P of KF92 equation 4, whose integrals over epsilon are taken analytically
         # via the arctan antiderivative below
         self._require_not_solved("add ionisation")
+        if self.heating_only_approximation:
+            # leave the ionisation loss out of the matrix. add_ionisation keeps the ion
+            # registration and the shell data that the analysis reads.
+            return
         deltaen = self.deltaen
         ionpot_ev = float(shell["ionpot_ev"])
         J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
@@ -996,19 +1019,23 @@ class SpencerFanoSolver:
         # if self.verbose:
         #     print(f"            frac_heating E_0 * y * l(E_0) part: {frac_heating_E_0_part:.5f}")
 
-        # E * N_e(E) is smooth over [0, E_0], so Simpson's rule earns its extra order here: it reaches
-        # 5e-5 of the converged value at 9 nodes where the trapezoid rule needs several hundred, and
-        # every node costs a full calculate_N_e(). Summing the nodes, as the code did before, counted
-        # half a node too much at each end of the interval.
-        arr_en = np.linspace(0.0, E_0, num=NPTS_SUB_E0_INTEGRAL, endpoint=True, dtype=np.float64)
-        arr_en_N_e = np.array([en_ev * self.calculate_N_e(en_ev) for en_ev in arr_en], dtype=np.float64)
-        integral_e_n_e = integrate_simpson_uniform(arr_en_N_e, arr_en)
-        frac_heating_N_e = integral_e_n_e / self.depositionratedensity_ev
+        # the heating-only matrix routes all deposited energy through the loss function, so the
+        # N_e term below E_0 would count the same energy twice. calculate_N_e() itself still
+        # gives the secondary-electron rate of the approximate solution.
+        if not self.heating_only_approximation:
+            # E * N_e(E) is smooth over [0, E_0], so Simpson's rule earns its extra order here: it
+            # reaches 5e-5 of the converged value at 9 nodes where the trapezoid rule needs several
+            # hundred, and every node costs a full calculate_N_e(). Summing the nodes, as the code
+            # did before, counted half a node too much at each end of the interval.
+            arr_en = np.linspace(0.0, E_0, num=NPTS_SUB_E0_INTEGRAL, endpoint=True, dtype=np.float64)
+            arr_en_N_e = np.array([en_ev * self.calculate_N_e(en_ev) for en_ev in arr_en], dtype=np.float64)
+            integral_e_n_e = integrate_simpson_uniform(arr_en_N_e, arr_en)
+            frac_heating_N_e = integral_e_n_e / self.depositionratedensity_ev
 
-        if self.verbose:
-            print(f" frac_heating(E<EMIN): {frac_heating_N_e:.5f}")
+            if self.verbose:
+                print(f" frac_heating(E<EMIN): {frac_heating_N_e:.5f}")
 
-        frac_heating += frac_heating_N_e
+            frac_heating += frac_heating_N_e
 
         self._frac_heating = frac_heating
         return frac_heating
@@ -1083,7 +1110,11 @@ class SpencerFanoSolver:
                         f" {shell['ionpot_ev']:.2f} eV)"
                     )
 
-                if not 0.0 <= frac_ionisation_shell <= 1.0:
+                # the heating-only approximation lets the fractions exceed one, so in that mode
+                # only a negative or NaN value is invalid (NaN fails every comparison)
+                if not frac_ionisation_shell >= 0.0 or (
+                    not self.heating_only_approximation and frac_ionisation_shell > 1.0
+                ):
                     warnings.warn(
                         f"invalid frac_ionisation_shell of {frac_ionisation_shell} included in the total",
                         stacklevel=2,
@@ -1110,7 +1141,9 @@ class SpencerFanoSolver:
 
             frac_excitation_thision = self.calculate_nt_frac_excitation_ion(Z, ion_stage)
 
-            if not 0.0 <= frac_excitation_thision <= 1.0:
+            if not frac_excitation_thision >= 0.0 or (
+                not self.heating_only_approximation and frac_excitation_thision > 1.0
+            ):
                 # keep it in the total, as for frac_ionisation_shell, so that the energy conservation
                 # check below still sees the problem instead of a total that silently lost a channel
                 warnings.warn(
@@ -1162,8 +1195,17 @@ class SpencerFanoSolver:
 
         # every deposited eV must end up in exactly one of the three channels. The tolerance is loose
         # enough to absorb the discretisation error of a coarse energy grid, so a warning here means
-        # a channel is being double counted or omitted rather than merely under-resolved.
-        if not math.isclose(frac_sum, 1.0, rel_tol=0.05):
+        # a channel is being double counted or omitted rather than merely under-resolved. The
+        # heating-only approximation makes the sum exceed one, so there the conserved quantity
+        # is the heating fraction alone, which must be close to one.
+        if self.heating_only_approximation:
+            if not math.isclose(frac_heating, 1.0, rel_tol=0.05):
+                warnings.warn(
+                    f"the heating fraction is {frac_heating:.4f} instead of 1 with the heating-only"
+                    f" approximation. Try a finer energy grid (npts is {len(self.engrid)}).",
+                    stacklevel=2,
+                )
+        elif not math.isclose(frac_sum, 1.0, rel_tol=0.05):
             warnings.warn(
                 f"the energy fractions sum to {frac_sum:.4f} instead of 1: heating {frac_heating:.4f},"
                 f" ionisation {self._frac_ionisation_tot:.4f}, excitation {self._frac_excitation_tot:.4f}."

--- a/pynonthermal/tests/test_sfsolve.py
+++ b/pynonthermal/tests/test_sfsolve.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -152,6 +153,56 @@ def test_helium() -> None:
         sf.plot_spec_channels(outputfilename=outputfolder / "spec_channels.pdf", xscalelog=True)
         sf.plot_yspectrum(outputfilename=outputfolder / "yspectrum.pdf")
         sf.plot_channels(outputfilename=outputfolder / "channels.pdf", xscalelog=True)
+
+
+def test_heating_only_approximation() -> None:
+    # with heating_only_approximation=True, the matrix contains no excitation or ionisation loss
+    # terms, but the analysis still calculates the channel rates from the heating-only solution
+    x_e = 1e-4
+    ions = [
+        # Z ion_stage numberdensity
+        (2, 1, 1.0 - x_e),
+        (2, 2, x_e),
+    ]
+
+    def build_solver(heating_only_approximation: bool) -> pynonthermal.SpencerFanoSolver:
+        # the assertions are qualitative, so a coarse grid is enough (test_helium covers npts=2000)
+        sf = pynonthermal.SpencerFanoSolver(
+            emin_ev=1, emax_ev=3000, npts=512, heating_only_approximation=heating_only_approximation
+        )
+        for Z, ion_stage, n_ion in ions:
+            sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
+            sf.add_ion_ltepopexcitation(Z, ion_stage, n_ion=n_ion, use_collstrengths=False)
+        return sf
+
+    with (
+        build_solver(heating_only_approximation=True) as sf_heat,
+        build_solver(heating_only_approximation=False) as sf_full,
+    ):
+        # the excitation and ionisation terms stay out of the matrix
+        assert not sf_heat.sfmatrix.any()
+        assert sf_full.sfmatrix.any()
+
+        sf_heat.solve(depositionratedensity_ev=100)
+        sf_full.solve(depositionratedensity_ev=100)
+
+        # the analysis of the heating-only solution must not show a solver warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            sf_heat.analyse_ntspectrum()
+
+        # heating takes almost all of the deposited energy
+        assert math.isclose(sf_heat.get_frac_heating(), 1.0, rel_tol=0.05)
+
+        # the channel rates are still available from the stored data
+        assert sf_heat.get_frac_ionisation_tot() > 0.0
+        assert sf_heat.get_frac_excitation_tot() > 0.0
+        assert sf_heat.get_ionisation_ratecoeff(2, 1) > 0.0
+        assert sf_heat.get_frac_ionisation_ion(2, 1) > 0.0
+
+        # without the competing loss terms, y(E) is larger, so the rates are larger
+        assert sf_heat.get_frac_ionisation_tot() > sf_full.get_frac_ionisation_tot()
+        assert sf_heat.get_frac_excitation_tot() > sf_full.get_frac_excitation_tot()
 
 
 def test_iron() -> None:


### PR DESCRIPTION
## What changed

- Add a `heating_only_approximation` option to the `SpencerFanoSolver` constructor. The option removes the excitation and ionisation loss terms from the Spencer-Fano matrix. The solver then finds y(E) with the heating (Coulomb) loss only.
- The solver keeps the stored excitation transitions and ionisation cross sections. The analysis then calculates the channel fractions and rate coefficients from this heating-only approximate solution.
- The channel fractions do not sum to one in this mode, so `analyse_ntspectrum` checks that the heating fraction is close to one instead of the frac_sum check. The 0..1 validity checks on the channel fractions waive only the upper bound; a negative or NaN fraction warns in every mode.
- `calculate_frac_heating` skips the N_e term below E_0 in this mode. The heating-only matrix routes all deposited energy through the loss function, so the term would count the same energy twice.
- `add_ion_ltepopexcitation` skips the band accumulation in this mode, because the matrix takes no excitation band.

## Why

The approximate heating-only solution is fast and shows the effect of the excitation and ionisation loss terms on the y(E) distribution and the derived rates.

## Notes for the reviewer

- The new test `test_heating_only_approximation` compares a heating-only solver with a full solver on the same pure-helium inputs. It checks that the matrix stays zero before the solve, that the analysis shows no warning, that the heating fraction is close to one, and that the heating-only rates exceed the full-solution rates.
- The default path (option off) keeps the previous behaviour. All 33 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)