### PR TITLE
Let the user add custom ionisation and excitation cross sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These quantities are important, for example, in modelling the late-time spectra 
 - [Units and conventions](#units-and-conventions)
 - [Method background](#method-background)
 - [Cross-section datasets](#cross-section-datasets)
-- [Advanced usage: custom excitation cross sections](#advanced-usage-custom-excitation-cross-sections)
+- [Advanced usage: custom cross sections](#advanced-usage-custom-cross-sections)
 - [Citing pynonthermal](#citing-pynonthermal)
 - [License](#license)
 
@@ -92,7 +92,7 @@ sf = pynonthermal.SpencerFanoSolver(emin_ev=1.0, emax_ev=3000.0, npts=4096, verb
 - `use_ar1985`: use the original Arnaud & Rothenflug (1985) ionisation cross sections (see [Cross-section datasets](#cross-section-datasets)).
 - `heating_only_approximation`: remove the excitation and ionisation loss terms from the matrix and solve with the heating loss only. The solver still calculates the excitation and ionisation rates from this approximate solution, so the channel fractions do not sum to one.
 
-The grid is available as `sf.engrid` (a NumPy array), which is needed if you supply [custom excitation cross sections](#advanced-usage-custom-excitation-cross-sections).
+The grid is available as `sf.engrid` (a NumPy array), which is needed if you supply [custom excitation cross sections](#custom-excitation-cross-sections).
 
 ### 2. Add ionisation channels
 
@@ -102,7 +102,7 @@ sf.add_ionisation(Z=8, ion_stage=2, n_ion=1.0e8)
 
 Adds every ionisation shell of the ion to the equation, using the built-in cross-section data. `Z` is the atomic number, `ion_stage` is one more than the ion charge (so `ion_stage=1` is neutral), and `n_ion` is the ion number density in cm^-3.
 
-Each ion may be added once; an ion with `n_ion=0.0` is silently skipped. If any of the ion's shells has an ionisation potential below `emin_ev`, a `ValueError` explains which lower `emin_ev` to use.
+Each ion may be added once through this method; an ion with `n_ion=0.0` is silently skipped. If any of the ion's shells has an ionisation potential below `emin_ev`, a `ValueError` explains which lower `emin_ev` to use. To add a channel that the built-in table does not hold, or to replace the built-in shells of an ion, use [`add_ionisation_channel()`](#custom-ionisation-cross-sections).
 
 The free electron density is computed automatically from the charges and densities of the added ions (`sf.get_n_e()`). At least one ionised species (or an explicit `override_n_e` in `solve()`) is required.
 
@@ -120,7 +120,7 @@ Optional parameters:
 - `maxnlevelslower`, `maxnlevelsupper`: only include transitions from the lowest `maxnlevelslower` levels up to the lowest `maxnlevelsupper` levels (defaults 5 and 250, matching ARTIS). Pass `None` to include all.
 - `use_collstrengths`: use tabulated collision strengths where available (default `True`); otherwise cross sections come from the oscillator strength via the van Regemorter approximation.
 
-Transitions with energies outside the energy grid are dropped. If the internal database has no data for the ion, a `ValueError` is raised — you can then either supply your own level/transition table via `adata_polars` or add [custom cross sections](#advanced-usage-custom-excitation-cross-sections) with `add_excitation()`.
+Transitions with energies outside the energy grid are dropped. If the internal database has no data for the ion, a `ValueError` is raised — you can then either supply your own level/transition table via `adata_polars` or add [custom cross sections](#custom-excitation-cross-sections) with `add_excitation()`.
 
 An ion added only for excitation still contributes its charge to the free electron density.
 
@@ -227,18 +227,39 @@ Ionization cross sections from H (Z=1) to Ni (Z=28) use the shell-resolved analy
 
 Passing `use_ar1985=True` to the solver selects the original Arnaud and Rothenflug (1985) compilation without the Fe updates, which can be useful for comparison with older published results.
 
-## Advanced usage: custom excitation cross sections
+## Advanced usage: custom cross sections
 
-You can supply your own excitation cross section table:
+Give a custom cross section as a NumPy array of cross sections (cm^2) at every energy in `sf.engrid` (eV),
+with `add_excitation()` or `add_ionisation_channel()`. Interpolate your own table onto `sf.engrid` first.
+
+A custom cross section follows the same path through the solver as a built-in one. The matrix, the energy
+fractions, and the rate coefficients therefore stay consistent.
+
+The examples below use NumPy:
 
 ```python
-sf.add_excitation(Z, ion_stage, levelnumberdensity, xs_vec, epsilon_trans_ev, transitionkey=(lower, upper))
+import numpy as np
+import pynonthermal
+```
+
+### Custom excitation cross sections
+
+```python
+sf.add_excitation(
+    Z=8,
+    ion_stage=2,
+    levelnumberdensity=1.0e8,
+    epsilon_trans_ev=20.0,
+    transitionkey=(0, 3),
+    xs_vec=np.interp(sf.engrid, my_en_ev, my_xs_cm2, left=0.0, right=0.0),
+)
 ```
 
 - `Z`: atomic number.
 - `ion_stage`: one more than ion charge.
 - `levelnumberdensity`: population density of the lower level (cm^-3), non-negative.
-- `xs_vec`: NumPy array of cross sections (cm^2), non-negative, defined at every energy in `sf.engrid` (eV).
+- `xs_vec`: a NumPy array of cross sections (cm^2), non-negative and finite, at every energy in
+  `sf.engrid` (eV). The solver keeps a read-only copy, so a later write to your own array cannot change it.
 - `epsilon_trans_ev`: transition energy (eV). Must be positive and no greater than `emax_ev`, since no
   electron the solver represents could otherwise drive the transition.
 - `transitionkey`: any unique key within the ion, used to retrieve the excitation rate coefficient.
@@ -248,6 +269,43 @@ Fransson (1992) take every electron below `emin_ev` to have thermalised, so that
 as heating instead.
 
 Retrieve the rate coefficient afterwards with `get_excitation_ratecoeff()` as in [step 5](#5-read-the-results).
+
+### Custom ionisation cross sections
+
+```python
+sf.add_ionisation_channel(
+    Z=8,
+    ion_stage=2,
+    n_ion=1.0e8,
+    ionpot_ev=35.0,
+    xs_vec=np.interp(sf.engrid, my_en_ev, my_xs_cm2, left=0.0, right=0.0),
+)
+```
+
+- `n_ion`: the ion number density (cm^-3). It must agree with the value that any other call for this ion
+  gives.
+- `ionpot_ev`: the ionisation potential of the channel (eV). It must be between `emin_ev` and `emax_ev`,
+  and the cross section must be zero at and below it. Any value in that range is allowed, so a channel need
+  not be a subshell of the built-in table. A total ionisation cross section for the ion works too.
+- `xs_vec`: a NumPy array of cross sections (cm^2), non-negative and finite, at every energy in
+  `sf.engrid` (eV).
+- `channelkey`: any unique key within the ion. The default is the number of channels the ion already has.
+
+Call `add_ionisation_channel()` once for each channel of the ion. To keep the built-in shells as well,
+also call `add_ionisation()` for the ion. To replace them, do not call `add_ionisation()` for it.
+
+A channel with `n_ion=0.0` is checked and then skipped, as `add_ionisation()` skips an ion.
+
+`calculate_N_e()` integrates over a domain just above the ionisation potential that is narrower than one
+grid cell, so the solver interpolates `xs_vec` between the grid points there. Resolve that region with
+`npts` if it matters for your ion: the term it feeds is the energy that thermalises below `emin_ev`, which
+is a small part of the heating fraction.
+
+The solver keeps the Lorentzian secondary-electron distribution of Kozma and Fransson (1992, equation 4),
+whose width comes from `pynonthermal.collion.get_J()`. The matrix fill integrates that distribution
+analytically, so its shape is not adjustable.
+
+Retrieve the rate coefficient afterwards with `get_ionisation_ratecoeff()` as in [step 5](#5-read-the-results).
 
 ## Citing pynonthermal
 

--- a/pynonthermal/__init__.py
+++ b/pynonthermal/__init__.py
@@ -5,8 +5,11 @@ from pynonthermal import base as base
 from pynonthermal import collion as collion
 from pynonthermal import constants as constants
 from pynonthermal import excitation as excitation
+from pynonthermal.base import CrossSectionFunc as CrossSectionFunc
 from pynonthermal.base import DATADIR as DATADIR
 from pynonthermal.base import electronlossfunction as electronlossfunction
 from pynonthermal.base import get_energyindex_gteq as get_energyindex_gteq
 from pynonthermal.base import get_energyindex_lteq as get_energyindex_lteq
+from pynonthermal.collion import IonisationChannel as IonisationChannel
+from pynonthermal.excitation import ExcitationTransition as ExcitationTransition
 from pynonthermal.spencerfano import SpencerFanoSolver as SpencerFanoSolver

--- a/pynonthermal/base.py
+++ b/pynonthermal/base.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import math
+from collections.abc import Callable
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -13,6 +14,55 @@ from pynonthermal.constants import ME
 from pynonthermal.constants import QE
 
 DATADIR = Path(__file__).absolute().parent / "data"
+
+# A cross section sigma(E) [cm^2] at an array of electron energies [eV].
+# An IonisationChannel holds one of these, because calculate_N_e() evaluates an ionisation cross
+# section between the points of the solver energy grid. A channel built from an array on that grid
+# interpolates the array there.
+type CrossSectionFunc = Callable[[npt.NDArray[np.float64]], npt.NDArray[np.float64]]
+
+
+def get_xs_on_grid(
+    xs: npt.NDArray[np.float64] | CrossSectionFunc, engrid: npt.NDArray[np.float64], name: str
+) -> npt.NDArray[np.float64]:
+    """Get the cross sections [cm^2] of xs on the energy grid engrid [eV], and check them.
+
+    xs is either an array on engrid or a function of an array of energies [eV]. name identifies
+    xs in an error message. The result is a new read-only array. A later write to the array of
+    the caller, or to a buffer that the function of the caller keeps, cannot change it.
+    """
+    # isinstance first, because callable() alone leaves the type checkers with an array that
+    # might also be callable
+    if isinstance(xs, np.ndarray):
+        arr_xs = xs
+    elif callable(xs):
+        arr_xs = xs(engrid)
+    else:
+        msg = f"{name} must be a numpy array on the energy grid, but it is a {type(xs).__name__}"
+        raise TypeError(msg)
+
+    # np.array copies, so the checks below hold for the lifetime of the result
+    xs_grid = np.array(arr_xs, dtype=np.float64)
+
+    if xs_grid.shape != engrid.shape:
+        msg = (
+            f"{name} must give one value for each of the {len(engrid)} energies of engrid,"
+            f" but it gave an array of shape {xs_grid.shape}"
+        )
+        raise ValueError(msg)
+
+    if not np.isfinite(xs_grid).all():
+        msg = f"{name} must be finite at every energy of the grid"
+        raise ValueError(msg)
+
+    if not (xs_grid >= 0.0).all():
+        msg = f"{name} must be non-negative but its lowest value is {xs_grid.min()} cm^2"
+        raise ValueError(msg)
+
+    # handed on to the solver, so a write must raise at the mutation site
+    xs_grid.flags.writeable = False
+
+    return xs_grid
 
 
 def get_betasq(en_ev: npt.NDArray[np.float64] | float) -> npt.NDArray[np.float64]:

--- a/pynonthermal/collion.py
+++ b/pynonthermal/collion.py
@@ -259,7 +259,7 @@ class IonisationChannel:
 
     Build a channel with from_xs(), which evaluates and checks the cross section.
     SpencerFanoSolver makes the built-in channels through get_ion_ionisation_channels(), and a
-    custom channel through SpencerFanoSolver.add_ionisation_table().
+    custom channel through SpencerFanoSolver.add_ionisation_channel().
     """
 
     ionpot_ev: float

--- a/pynonthermal/collion.py
+++ b/pynonthermal/collion.py
@@ -1,3 +1,6 @@
+import math
+import typing as t
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
@@ -9,7 +12,40 @@ import pynonthermal
 from pynonthermal.axelrod import get_binding_energies
 from pynonthermal.axelrod import get_lotz_xs_ionisation_vec
 from pynonthermal.axelrod import get_shell_configs
+from pynonthermal.base import CrossSectionFunc
+from pynonthermal.base import get_xs_on_grid
 from pynonthermal.constants import EV
+
+SUBSHELLNAMES = [
+    "K ",
+    "L1",
+    "L2",
+    "L3",
+    "M1",
+    "M2",
+    "M3",
+    "M4",
+    "M5",
+    "N1",
+    "N2",
+    "N3",
+    "N4",
+    "N5",
+    "N6",
+    "N7",
+    "O1",
+    "O2",
+    "O3",
+    "O4",
+    "O5",
+    "O6",
+    "O7",
+    "P1",
+    "P2",
+    "P3",
+    "P4",
+    "Q1",
+]
 
 
 @lru_cache
@@ -211,3 +247,183 @@ def get_arxs_array_shell(arr_enev: npt.NDArray[np.float64], shell: dict[str, int
         / (u * ionpot_ev**2),
     )
     return xs
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class IonisationChannel:
+    """One collisional ionisation channel of an ion, with the cross section that the solver uses.
+
+    The channel carries neither the atomic number nor the ion stage nor the ion number density.
+    The solver holds a list of channels for each ion, and it holds the number densities in
+    SpencerFanoSolver.ionpopdict.
+
+    Build a channel with from_xs(), which evaluates and checks the cross section.
+    SpencerFanoSolver makes the built-in channels through get_ion_ionisation_channels(), and a
+    custom channel through SpencerFanoSolver.add_ionisation_table().
+    """
+
+    ionpot_ev: float
+    """The ionisation potential of the channel [eV]."""
+
+    xs: CrossSectionFunc
+    """The cross section sigma(E) [cm^2] at any array of energies [eV].
+
+    calculate_N_e() evaluates this between the grid points, just above the ionisation potential.
+    The domain of that integral is narrower than one grid cell. A function is therefore necessary
+    here, and an array on the grid is not enough.
+    """
+
+    xs_grid: npt.NDArray[np.float64]
+    """The cross section [cm^2] at every energy of SpencerFanoSolver.engrid."""
+
+    J_ev: float
+    """The width of the secondary-electron distribution [eV], from get_J()."""
+
+    key: t.Any
+    """A key that identifies the channel in its ion, and names it in the verbose output."""
+
+    @classmethod
+    def from_xs_grid(
+        cls,
+        arr_enev: npt.NDArray[np.float64],
+        Z: int,
+        ion_stage: int,
+        ionpot_ev: float,
+        xs_vec: npt.NDArray[np.float64],
+        key: t.Any,
+    ) -> t.Self:
+        """Make a channel from cross sections [cm^2] at every energy of the grid arr_enev [eV]."""
+        name = f"The cross section of ionisation channel {key}"
+        xs_grid = get_xs_on_grid(xs_vec, arr_enev, name)
+        # check the array of the caller here. The interpolation below holds the cross section at
+        # zero up to the ionisation potential, so from_xs() would find nothing left to reject.
+        _check_zero_below_ionpot(arr_enev, xs_grid, float(ionpot_ev), name)
+
+        return cls.from_xs(
+            arr_enev=arr_enev,
+            Z=Z,
+            ion_stage=ion_stage,
+            ionpot_ev=ionpot_ev,
+            xs=_interpolate_grid_xs(arr_enev, xs_grid, float(ionpot_ev)),
+            key=key,
+        )
+
+    @classmethod
+    def from_xs(
+        cls,
+        arr_enev: npt.NDArray[np.float64],
+        Z: int,
+        ion_stage: int,
+        ionpot_ev: float,
+        xs: CrossSectionFunc,
+        key: t.Any,
+    ) -> t.Self:
+        """Make a channel, and check the cross section that xs gives on the energy grid arr_enev [eV].
+
+        get_J() gives the width of the secondary-electron distribution from Z, ion_stage, and
+        ionpot_ev, so the channel is always consistent with its ionisation potential.
+        """
+        name = f"The cross section of ionisation channel {key}"
+
+        # the chained comparison also rejects nan, for which every comparison is False
+        if not 0.0 < ionpot_ev < math.inf:
+            msg = f"ionpot_ev must be greater than zero and finite but is {ionpot_ev}"
+            raise ValueError(msg)
+
+        xs_grid = get_xs_on_grid(xs, arr_enev, name)
+
+        _check_zero_below_ionpot(arr_enev, xs_grid, float(ionpot_ev), name)
+
+        # calculate_N_e() evaluates the cross section between the points of the energy grid, so a
+        # function that ignores its argument fails there. The probe finds that at the call site,
+        # where the message can name the channel.
+        probe_enev = np.linspace(float(arr_enev[0]), float(arr_enev[-1]), num=3 if len(arr_enev) != 3 else 4)
+        probe_xs = np.asarray(xs(probe_enev), dtype=np.float64)
+        if probe_xs.shape != probe_enev.shape:
+            msg = (
+                f"{name} must give one value for each energy that it receives, but it gave"
+                f" {probe_xs.shape} values for {len(probe_enev)} energies."
+                " The solver also evaluates it between the points of the energy grid."
+            )
+            raise ValueError(msg)
+
+        return cls(
+            ionpot_ev=float(ionpot_ev),
+            xs=xs,
+            xs_grid=xs_grid,
+            J_ev=get_J(Z, ion_stage, float(ionpot_ev)),
+            key=key,
+        )
+
+
+def _check_zero_below_ionpot(
+    arr_enev: npt.NDArray[np.float64], xs_grid: npt.NDArray[np.float64], ionpot_ev: float, name: str
+) -> None:
+    # the matrix fill starts at the ionisation potential, but the analysis integrates the whole
+    # grid. A cross section below the ionisation potential therefore adds to the ionisation
+    # fraction without a matching loss term. The energy fractions would then not sum to one, and
+    # nothing would say why.
+    subthreshold = np.flatnonzero((arr_enev <= ionpot_ev) & (xs_grid > 0.0))
+    if len(subthreshold) > 0:
+        i = int(subthreshold[-1])
+        msg = (
+            f"{name} must be zero at and below its ionisation potential of {ionpot_ev} eV,"
+            f" but it is {xs_grid[i]} cm^2 at {arr_enev[i]} eV."
+            " Give the energy at which the cross section starts."
+        )
+        raise ValueError(msg)
+
+
+def _interpolate_grid_xs(
+    arr_enev: npt.NDArray[np.float64], xs_grid: npt.NDArray[np.float64], ionpot_ev: float
+) -> CrossSectionFunc:
+    # calculate_N_e() evaluates the cross section between the points of the energy grid, just above
+    # the ionisation potential, so a channel given as an array on that grid interpolates it there.
+    # The np.where keeps the function at zero below its own ionisation potential, where a straight
+    # interpolation from the last grid point below it would give a small positive value.
+    def xs(en_ev: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return np.where(en_ev > ionpot_ev, np.interp(en_ev, arr_enev, xs_grid, left=0.0, right=0.0), 0.0)
+
+    return xs
+
+
+def _bind_shell(shell: dict[str, t.Any]) -> CrossSectionFunc:
+    # give each channel its own shell row, and keep the call to the formula positional
+    def xs(arr_enev: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return get_arxs_array_shell(arr_enev, shell)
+
+    return xs
+
+
+def get_ion_ionisation_channels(
+    dfcollion: pl.DataFrame,
+    Z: int,
+    ion_stage: int,
+    arr_enev: npt.NDArray[np.float64],
+) -> list[IonisationChannel]:
+    """Get one ionisation channel for every subshell of an ion in the fit table dfcollion.
+
+    arr_enev:
+        the energy grid [eV] on which to evaluate and check each cross section
+    """
+    shells = dfcollion.filter((pl.col("Z") == Z) & (pl.col("ion_stage") == ion_stage)).to_dicts()
+    if not shells:
+        msg = f"No ionisation cross-section data for Z={Z} ion_stage {ion_stage}"
+        raise ValueError(msg)
+
+    return [
+        IonisationChannel.from_xs(
+            arr_enev=arr_enev,
+            Z=Z,
+            ion_stage=ion_stage,
+            ionpot_ev=float(shell["ionpot_ev"]),
+            xs=_bind_shell(shell),
+            # the key names the subshell, so the verbose output needs no separate label
+            key=(
+                f"Lotz shell {SUBSHELLNAMES[-int(shell['l'])]}"
+                if int(shell["n"]) < 0
+                else f"n {int(shell['n'])} l {int(shell['l'])}"
+            ),
+        )
+        for shell in shells
+    ]

--- a/pynonthermal/excitation.py
+++ b/pynonthermal/excitation.py
@@ -1,5 +1,6 @@
 import math
 import typing as t
+from dataclasses import dataclass
 
 import numpy as np
 import numpy.typing as npt
@@ -11,6 +12,25 @@ from pynonthermal.constants import H
 from pynonthermal.constants import H_ionpot
 from pynonthermal.constants import ME
 from pynonthermal.constants import QE
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class ExcitationTransition:
+    """One bound-bound excitation that the solver holds, as SpencerFanoSolver.add_excitation() records it.
+
+    The cross section is an array on the solver energy grid, because every reader needs it only
+    there: the matrix fill, the excitation fraction of Kozma & Fransson 1992 equation 9, and the
+    single interpolated point that calculate_N_e() takes at energy_ev + epsilon_trans_ev.
+    """
+
+    levelnumberdensity: float
+    """The population density of the lower level [cm^-3]."""
+
+    xs_vec: npt.NDArray[np.float64]
+    """The cross section [cm^2] at every energy of SpencerFanoSolver.engrid."""
+
+    epsilon_trans_ev: float
+    """The transition energy [eV]."""
 
 
 def get_xs_excitation_vector(

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -16,9 +16,12 @@ import pynonthermal
 from pynonthermal.axelrod import get_workfn_ev
 from pynonthermal.base import electronlossfunction
 from pynonthermal.base import get_betasq
+from pynonthermal.base import get_xs_on_grid
 from pynonthermal.base import get_Zbar
+from pynonthermal.collion import IonisationChannel
 from pynonthermal.constants import CLIGHT
 from pynonthermal.constants import K_B
+from pynonthermal.excitation import ExcitationTransition
 
 # Nodes for the sub-grids that resolve the parts of the Kozma & Fransson equation 11 integrals that the
 # solver's own energy grid cannot. Both integrands vary on the scale of J = 0.6 * ionpot_ev, so the node
@@ -40,37 +43,6 @@ NCELLS_SECOND_INTEGRAL_SUBGRID: int = 2
 # integral alone: the old ceil(E_0 / deltaen) * 5 tied it to the main grid, which gave 5 nodes when
 # emin_ev was below the grid spacing and several hundred when it was well above.
 NPTS_SUB_E0_INTEGRAL: int = 9
-
-SUBSHELLNAMES = [
-    "K ",
-    "L1",
-    "L2",
-    "L3",
-    "M1",
-    "M2",
-    "M3",
-    "M4",
-    "M5",
-    "N1",
-    "N2",
-    "N3",
-    "N4",
-    "N5",
-    "N6",
-    "N7",
-    "O1",
-    "O2",
-    "O3",
-    "O4",
-    "O5",
-    "O6",
-    "O7",
-    "P1",
-    "P2",
-    "P3",
-    "P4",
-    "Q1",
-]
 
 
 def solve_upper_triangular(
@@ -143,9 +115,10 @@ class SpencerFanoSolver:
       add_ion_ltepopexcitation(), with cross sections from pynonthermal.excitation
       (Li et al. 2012 equation 11 from a collision strength, or the van Regemorter 1962
       approximation with the Mewe 1972 g-bar factor)
-    - the ionisation term, integrals of y(E') sigma_ic(E') P(E', epsilon - I) with the shell's
+    - the ionisation term, integrals of y(E') sigma_ic(E') P(E', epsilon - I) with the channel's
       total ionisation cross section sigma_ic (pynonthermal.collion) and the secondary-electron
-      energy distribution P of KF92 equation 4: add_ionisation(), via _add_ionisation_shell()
+      energy distribution P of KF92 equation 4: add_ionisation() and add_ionisation_channel(),
+      via _add_ionisation_channel_to_matrix()
     - the right-hand side, the integral of the source function from E to E_max: rhsvec,
       built in __init__ for a source spread over the top of the energy grid
 
@@ -156,6 +129,9 @@ class SpencerFanoSolver:
     (KF92 equation 12, summed over shells in analyse_ntspectrum()) with rate coefficients
     from get_ionisation_ratecoeff() (KF92 equation 13). calculate_N_e() evaluates N(E) of
     KF92 equation 11, the rate at which electrons appear below the solved grid.
+
+    Every cross section is adjustable. add_excitation() and add_ionisation_channel() each take one
+    custom cross section, as an array of cross sections at every energy of the solver energy grid.
 
     If heating_only_approximation is True, the solver removes the excitation and ionisation
     loss terms from the matrix and keeps only the heating loss. The solver still stores the
@@ -173,12 +149,10 @@ class SpencerFanoSolver:
     _frac_excitation_ion: dict[tuple[int, int], float]
     _eff_ionpot: dict[tuple[int, int], float]
     _nt_ionisation_ratecoeff: dict[tuple[int, int], float]
-    _ionisation_ions: set[tuple[int, int]]
-    _collionrows_ion: dict[tuple[int, int], list[dict[str, t.Any]]]
-    _shell_xs: dict[tuple[int, int, int, int, float], npt.NDArray[np.float64]]
+    _ionisation_channels: dict[tuple[int, int], list[IonisationChannel]]
     depositionratedensity_ev: float
     ionpopdict: dict[tuple[int, int], float]
-    excitationlists: dict[tuple[int, int], dict[t.Any, tuple[float, npt.NDArray[np.float64], float]]]
+    excitationlists: dict[tuple[int, int], dict[t.Any, ExcitationTransition]]
     verbose: bool
     heating_only_approximation: bool
     _n_e: float | None
@@ -222,18 +196,20 @@ class SpencerFanoSolver:
         self._n_e_override = None
         self.reset_solution_analysis()
 
-        self._collionrows_ion = {}  # cache of collisional ionisation shell data per (Z, ion_stage)
-        self._shell_xs = {}  # cache of ionisation cross section arrays per shell
+        # key is (Z, ion_stage), value is the list of that ion's ionisation channels
+        self._ionisation_channels = {}
 
         self.ionpopdict = {}  # key is (Z, ion_stage) value is number density
-        self._ionisation_ions = set()  # ions passed to add_ionisation(), i.e. those with ionisation channels
 
-        # key is (Z, ion_stage) value is {levelkey : (levelnumberdensity, xs_vec, epsilon_trans_ev)}
+        # key is (Z, ion_stage) value is {transitionkey: ExcitationTransition}
         self.excitationlists = {}
 
         self.verbose = verbose
         self.heating_only_approximation = heating_only_approximation
         self.engrid = np.linspace(emin_ev, emax_ev, num=npts, endpoint=True, dtype=float)
+        # handed to the cross section functions of the caller, so a write must raise at the
+        # mutation site. An in-place write would otherwise leave the grid and deltaen inconsistent.
+        self.engrid.flags.writeable = False
         self.deltaen = self.engrid[1] - self.engrid[0]
 
         self.dfcollion = pynonthermal.collion.read_colliondata(
@@ -309,8 +285,18 @@ class SpencerFanoSolver:
 
     def _register_ion_population(self, Z: int, ion_stage: int, n_ion: float) -> None:
         # an ion's number density must agree between its ionisation and excitation calls
-        if n_ion < 0.0:
-            msg = f"n_ion must be non-negative but is {n_ion}"
+        if Z < 1:
+            msg = f"Z must be at least 1 but is {Z}"
+            raise ValueError(msg)
+        # ion_stage is one more than the charge, so a value below one gives a negative charge and
+        # a negative free electron density
+        if ion_stage < 1:
+            msg = f"ion_stage must be at least 1 (neutral) but is {ion_stage}"
+            raise ValueError(msg)
+        # the chained comparison also rejects nan, for which every comparison is False, and inf,
+        # which would make the free electron density infinite without ever raising
+        if not 0.0 <= n_ion < math.inf:
+            msg = f"n_ion must be non-negative and finite but is {n_ion}"
             raise ValueError(msg)
 
         n_ion_existing = self.ionpopdict.get((Z, ion_stage))
@@ -322,21 +308,33 @@ class SpencerFanoSolver:
         # the free electron density derived from the ion populations is no longer current
         self._n_e = None
 
-    def _get_ion_collion_rows(self, Z: int, ion_stage: int) -> list[dict[str, t.Any]]:
-        # collisional ionisation shell data rows for one ion (cached)
-        key = (Z, ion_stage)
-        if key not in self._collionrows_ion:
-            self._collionrows_ion[key] = self.dfcollion.filter(
-                (pl.col("Z") == Z) & (pl.col("ion_stage") == ion_stage)
-            ).to_dicts()
-        return self._collionrows_ion[key]
+    def _check_ionpot_above_emin(self, Z: int, ion_stage: int, ionpots_ev: list[float]) -> None:
+        # Kozma & Fransson 1992 assume that every threshold lies above the low-energy cutoff E_0, so that
+        # all energy reaching E_0 is thermalised by the free electrons. A channel below E_0 breaks that
+        # assumption and can't be accounted for consistently: leaving it out of the matrix drops a real
+        # energy sink, and including it credits ionisation below E_0 that the heating term already claims.
+        ionpots_below_emin = sorted(ionpot_ev for ionpot_ev in ionpots_ev if ionpot_ev < self.engrid[0])
+        if ionpots_below_emin:
+            msg = (
+                f"Z={Z} ion_stage {ion_stage} has {len(ionpots_below_emin)} ionisation channel(s) with a"
+                f" ionisation potential below emin_ev={self.engrid[0]} eV (lowest {ionpots_below_emin[0]} eV)."
+                f" The energy fractions would not sum to one, so set emin_ev <= {ionpots_below_emin[0]} eV."
+            )
+            raise ValueError(msg)
 
-    def _get_shell_xs(self, shell: dict[str, t.Any]) -> npt.NDArray[np.float64]:
-        # ionisation cross sections on the energy grid for one shell (cached)
-        key = (int(shell["Z"]), int(shell["ion_stage"]), int(shell["n"]), int(shell["l"]), float(shell["ionpot_ev"]))
-        if key not in self._shell_xs:
-            self._shell_xs[key] = pynonthermal.collion.get_arxs_array_shell(self.engrid, shell)
-        return self._shell_xs[key]
+    def _check_ionisation_channel_keys(self, Z: int, ion_stage: int, keys: list[t.Any]) -> None:
+        # every channel of an ion needs its own key. This runs before any channel is stored, so a
+        # rejected call leaves the solver unchanged instead of half-adding the ion.
+        seen = {channel.key for channel in self._ionisation_channels.get((Z, ion_stage), [])}
+        for key in keys:
+            if key in seen:
+                msg = f"Ionisation channel {key} already added for Z={Z} ion_stage={ion_stage}"
+                raise ValueError(msg)
+            seen.add(key)
+
+    def _store_ionisation_channel(self, Z: int, ion_stage: int, channel: IonisationChannel) -> None:
+        # record one channel for an ion. _check_ionisation_channel_keys() runs first.
+        self._ionisation_channels.setdefault((Z, ion_stage), []).append(channel)
 
     def add_excitation(
         self,
@@ -356,7 +354,9 @@ class SpencerFanoSolver:
         levelnumberdensity:
             the level population density in cm^-3
         xs_vec:
-            an array of cross sections in cm^2 defined at every energy in the SpencerFanoSolver.engrid array [eV]
+            an array of cross sections in cm^2 at every energy of the SpencerFanoSolver.engrid
+            array [eV]. The solver keeps a read-only copy, so a later write to your own array
+            cannot change it.
         epsilon_trans_ev:
             the transition energy in eV
         transitionkey:
@@ -378,9 +378,9 @@ class SpencerFanoSolver:
         # (zeroed below the threshold index, where no grid electron can drive the transition),
         # the band width k in whole bins, and the weight frac of the partial final bin
         self._require_not_solved("add excitation")
-        if len(xs_vec) != len(self.engrid):
-            msg = f"xs_vec has {len(xs_vec)} points but engrid has {len(self.engrid)}"
-            raise ValueError(msg)
+        # get_xs_on_grid() returns a read-only copy, so a later write by the caller cannot change
+        # what the solver holds
+        xs_vec = get_xs_on_grid(xs_vec, self.engrid, "xs_vec")
 
         # a non-positive transition energy would put matrix entries below the diagonal, where the
         # triangular solve silently discards them, and a negative population or cross section would
@@ -398,10 +398,6 @@ class SpencerFanoSolver:
         if not levelnumberdensity >= 0.0:
             msg = f"levelnumberdensity must be non-negative but is {levelnumberdensity}"
             raise ValueError(msg)
-        if not (xs_vec >= 0.0).all():
-            msg = f"xs_vec must be non-negative and finite but its lowest value is {xs_vec.min()}"
-            raise ValueError(msg)
-
         if (Z, ion_stage) not in self.excitationlists:
             self.excitationlists[(Z, ion_stage)] = {}
 
@@ -411,10 +407,10 @@ class SpencerFanoSolver:
         if transitionkey in self.excitationlists[(Z, ion_stage)]:
             msg = f"Transition {transitionkey} already added for Z={Z} ion_stage={ion_stage}"
             raise ValueError(msg)
-        self.excitationlists[(Z, ion_stage)][transitionkey] = (
-            levelnumberdensity,
-            xs_vec,
-            epsilon_trans_ev,
+        self.excitationlists[(Z, ion_stage)][transitionkey] = ExcitationTransition(
+            levelnumberdensity=levelnumberdensity,
+            xs_vec=xs_vec,
+            epsilon_trans_ev=epsilon_trans_ev,
         )
         vec = levelnumberdensity * self.deltaen * xs_vec  # cross section times level density times bin width
         vec[: self.get_energyindex_lteq(en_ev=epsilon_trans_ev)] = 0.0
@@ -602,24 +598,25 @@ class SpencerFanoSolver:
                 for k, (groupvec, groupfracvec) in sorted(groups.items()):
                     self._add_excitation_band(groupvec, groupfracvec, k)
 
-    def _add_ionisation_shell(self, n_ion: float, shell: dict[str, int | float]) -> None:
-        # add one shell's contribution to the ionisation term of the degradation equation
+    def _add_ionisation_channel_to_matrix(self, n_ion: float, channel: IonisationChannel) -> None:
+        # add one channel's contribution to the ionisation term of the degradation equation
         # (Kozma & Fransson 1992 equation 7): integrals of y(E') sigma_ic(E') P(E', epsilon - I),
-        # using their equation 5 factorisation of the differential cross section into the shell's
-        # total cross section sigma_ic (from _get_shell_xs) times the secondary-electron energy
+        # using their equation 5 factorisation of the differential cross section into the channel's
+        # total cross section sigma_ic (IonisationChannel.xs_grid) times the secondary-electron energy
         # distribution P of KF92 equation 4, whose integrals over epsilon are taken analytically
-        # via the arctan antiderivative below
+        # via the arctan antiderivative below. That analytic step fixes the shape of P, so a channel
+        # sets only its width J and not the shape.
         self._require_not_solved("add ionisation")
         if self.heating_only_approximation:
             # leave the ionisation loss out of the matrix. add_ionisation keeps the ion
-            # registration and the shell data that the analysis reads.
+            # registration and the channel data that the analysis reads.
             return
         deltaen = self.deltaen
-        ionpot_ev = float(shell["ionpot_ev"])
-        J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
+        ionpot_ev = channel.ionpot_ev
+        J = channel.J_ev
         npts = len(self.engrid)
 
-        ar_xs_array = self._get_shell_xs(shell)
+        ar_xs_array = channel.xs_grid
 
         xsstartindex = 0 if ionpot_ev <= self.engrid[0] else self.get_energyindex_gteq(en_ev=ionpot_ev)
 
@@ -697,42 +694,26 @@ class SpencerFanoSolver:
         """Add collisional ionisation of one ion, contributing every shell with cross-section data.
 
         The shells enter the ionisation term of the degradation equation (Kozma & Fransson 1992
-        equation 7). Each ion may be added only once; an ion with n_ion of exactly zero is skipped
-        without being registered. A ValueError is raised if any shell's ionisation potential lies
-        below the energy grid's emin_ev (the message gives the emin_ev to use instead).
+        equation 7). Each ion may be added only once through this method; an ion with n_ion of
+        exactly zero is skipped without being registered. A ValueError is raised if any shell's
+        ionisation potential lies below the energy grid's emin_ev (the message gives the emin_ev
+        to use instead). To add a channel that the built-in table does not hold, or to replace the
+        built-in shells of an ion, use add_ionisation_table() instead.
 
         n_ion:
             the ion number density in cm^-3
         """
         self._require_not_solved("add ionisation")
-        if (Z, ion_stage) in self._ionisation_ions:
-            msg = f"Can't add Z={Z} ion_stage {ion_stage} twice"
+        if not 0.0 <= n_ion < math.inf:
+            msg = f"n_ion must be non-negative and finite but is {n_ion}"
             raise ValueError(msg)
         if n_ion == 0.0:
             return
-        if n_ion < 0.0:
-            msg = f"n_ion must be non-negative but is {n_ion}"
-            raise ValueError(msg)
 
-        collionrows = self._get_ion_collion_rows(Z, ion_stage)
-        if not collionrows:
-            msg = f"No ionisation cross-section data for Z={Z} ion_stage {ion_stage}"
-            raise ValueError(msg)
+        channels = pynonthermal.collion.get_ion_ionisation_channels(self.dfcollion, Z, ion_stage, self.engrid)
 
-        # Kozma & Fransson 1992 assume that every threshold lies above the low-energy cutoff E_0, so that
-        # all energy reaching E_0 is thermalised by the free electrons. A shell below E_0 breaks that
-        # assumption and can't be accounted for consistently: leaving it out of the matrix drops a real
-        # energy sink, and including it credits ionisation below E_0 that the heating term already claims.
-        ionpots_below_emin = sorted(
-            float(shell["ionpot_ev"]) for shell in collionrows if shell["ionpot_ev"] < self.engrid[0]
-        )
-        if ionpots_below_emin:
-            msg = (
-                f"Z={Z} ion_stage {ion_stage} has {len(ionpots_below_emin)} ionisation shell(s) with an"
-                f" ionisation potential below emin_ev={self.engrid[0]} eV (lowest {ionpots_below_emin[0]} eV)."
-                f" The energy fractions would not sum to one, so set emin_ev <= {ionpots_below_emin[0]} eV."
-            )
-            raise ValueError(msg)
+        self._check_ionpot_above_emin(Z, ion_stage, [channel.ionpot_ev for channel in channels])
+        self._check_ionisation_channel_keys(Z, ion_stage, [channel.key for channel in channels])
 
         if self.verbose:
             print(
@@ -741,10 +722,89 @@ class SpencerFanoSolver:
                 f" {n_ion:.1e} [/cm3]"
             )
         self._register_ion_population(Z, ion_stage, n_ion)
-        self._ionisation_ions.add((Z, ion_stage))
 
-        for shell in collionrows:
-            self._add_ionisation_shell(n_ion, shell)
+        for channel in channels:
+            self._store_ionisation_channel(Z, ion_stage, channel)
+            self._add_ionisation_channel_to_matrix(n_ion, channel)
+
+    def add_ionisation_channel(
+        self,
+        Z: int,
+        ion_stage: int,
+        n_ion: float,
+        ionpot_ev: float,
+        xs_vec: npt.NDArray[np.float64],
+        channelkey: t.Any | None = None,
+    ) -> None:
+        """Add one collisional ionisation channel of an ion, with a custom cross section.
+
+        The channel enters the ionisation term of the degradation equation (Kozma & Fransson 1992
+        equation 7) in the same way as a shell of the built-in table. Call this method as many
+        times as the ion has channels. To keep the built-in shells as well, also call
+        add_ionisation() for the ion; to replace them, do not call add_ionisation() for it.
+
+        The solver keeps the Lorentzian secondary-electron distribution of Kozma & Fransson 1992
+        equation 4, whose width comes from pynonthermal.collion.get_J(Z, ion_stage, ionpot_ev).
+        The matrix fill integrates that distribution analytically, so the shape is not adjustable.
+
+        n_ion:
+            the ion number density in cm^-3. It must agree with the value that any other call
+            for this ion gives.
+        ionpot_ev:
+            the ionisation potential of the channel in eV. It must be between emin_ev and
+            emax_ev. The cross section must be zero at and below it.
+        xs_vec:
+            an array of cross sections in cm^2 at every energy of the SpencerFanoSolver.engrid
+            array [eV]. The solver keeps a read-only copy, so a later write to your own array
+            cannot change it. calculate_N_e() needs the cross section between the grid points
+            just above the ionisation potential, and interpolates the array there.
+        channelkey:
+            any key to identify the channel in the ion. The default is the number of channels
+            that the ion already has.
+        """
+        self._require_not_solved("add ionisation")
+        if not 0.0 <= n_ion < math.inf:
+            msg = f"n_ion must be non-negative and finite but is {n_ion}"
+            raise ValueError(msg)
+
+        if ionpot_ev > self.engrid[-1]:
+            # the matrix fill would write nothing and the channel would be inert. The equivalent
+            # excitation check is in _store_excitation().
+            msg = (
+                f"ionpot_ev ({ionpot_ev} eV) is above the top of the energy grid"
+                f" ({self.engrid[-1]} eV), so no electron the solver represents can ionise this channel"
+            )
+            raise ValueError(msg)
+
+        if channelkey is None:
+            channelkey = len(self._ionisation_channels.get((Z, ion_stage), []))
+
+        # every check runs before anything is recorded, so a rejected call leaves the solver
+        # unchanged. The cross section is checked even for a zero population, which adds no channel.
+        channel = IonisationChannel.from_xs_grid(
+            arr_enev=self.engrid,
+            Z=Z,
+            ion_stage=ion_stage,
+            ionpot_ev=ionpot_ev,
+            xs_vec=xs_vec,
+            key=channelkey,
+        )
+        self._check_ionpot_above_emin(Z, ion_stage, [channel.ionpot_ev])
+        self._check_ionisation_channel_keys(Z, ion_stage, [channel.key])
+
+        if n_ion == 0.0:
+            return
+
+        if self.verbose:
+            print(
+                f"  including Z={Z} ion_stage {ion_stage} ({at.get_ionstring(Z, ion_stage)})"
+                f" ionisation channel {channelkey} (ionpot {ionpot_ev:.2f} eV) with n_ion"
+                f" {n_ion:.1e} [/cm3]"
+            )
+
+        self._register_ion_population(Z, ion_stage, n_ion)
+        self._store_ionisation_channel(Z, ion_stage, channel)
+        self._add_ionisation_channel_to_matrix(n_ion, channel)
 
     def calculate_free_electron_density(self) -> float:
         # number density of free electrons [cm^-3]
@@ -840,12 +900,8 @@ class SpencerFanoSolver:
 
         xs_excitation_vec_sum_alltrans = np.zeros(npts)
 
-        for (
-            levelnumberdensity,
-            xsvec,
-            epsilon_trans_ev,
-        ) in self.excitationlists[(Z, ion_stage)].values():
-            xs_excitation_vec_sum_alltrans += levelnumberdensity * epsilon_trans_ev * xsvec
+        for trans in self.excitationlists[(Z, ion_stage)].values():
+            xs_excitation_vec_sum_alltrans += trans.levelnumberdensity * trans.epsilon_trans_ev * trans.xs_vec
 
         return np.dot(xs_excitation_vec_sum_alltrans, self.yvec) * deltaen / self.depositionratedensity_ev
 
@@ -897,7 +953,7 @@ class SpencerFanoSolver:
             N_e_ion = 0.0
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
 
-            for levelnumberdensity, xsvec, epsilon_trans_ev in self.excitationlists.get((Z, ion_stage), {}).values():
+            for trans in self.excitationlists.get((Z, ion_stage), {}).values():
                 # Interpolate y and the cross section at energy_ev + epsilon_trans_ev, as the two
                 # ionisation integrals below also do, rather than snapping down to the grid point under
                 # it. Snapping lands below the transition energy whenever E has not yet carried the sum
@@ -907,26 +963,24 @@ class SpencerFanoSolver:
                 # than left to np.interp because this runs once per transition per quadrature node,
                 # where the call overhead of np.interp costs more than the arithmetic; the grid is
                 # uniform, so the index and weight are exact.
-                en_upper = energy_ev + epsilon_trans_ev
+                en_upper = energy_ev + trans.epsilon_trans_ev
                 if e_min <= en_upper <= e_max:
                     pos = (en_upper - e_min) / deltaen
                     i = min(int(pos), lastindex)
                     weight = pos - i
+                    xsvec = trans.xs_vec
                     # the level population is absolute, so this term is not scaled by n_ion below
                     N_e += (
-                        levelnumberdensity
+                        trans.levelnumberdensity
                         * (self.yvec[i] + weight * (self.yvec[i + 1] - self.yvec[i]))
                         * (xsvec[i] + weight * (xsvec[i + 1] - xsvec[i]))
                     )
 
-            if (Z, ion_stage) not in self._ionisation_ions:
-                continue
-
-            for shell in self._get_ion_collion_rows(Z, ion_stage):
-                ionpot_ev = float(shell["ionpot_ev"])
+            for channel in self._ionisation_channels.get((Z, ion_stage), ()):
+                ionpot_ev = channel.ionpot_ev
 
                 enlambda = min(e_max - energy_ev, energy_ev + ionpot_ev)
-                J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
+                J = channel.J_ev
 
                 # Integral over epsilon from ionpot_ev to enlambda. Its width is at most energy_ev, which
                 # is at most E_0 = emin_ev, so it is usually narrower than one cell of self.engrid and has
@@ -945,7 +999,7 @@ class SpencerFanoSolver:
                         arr_e_p=arr_e_p,
                         # asarray because np.interp is typed as returning a scalar for a scalar x
                         arr_y=np.asarray(np.interp(arr_e_p, self.engrid, self.yvec, left=0.0, right=0.0)),
-                        arr_xs=pynonthermal.collion.get_arxs_array_shell(arr_e_p, shell),
+                        arr_xs=channel.xs(arr_e_p),
                         e_s=arr_epsilon - ionpot_ev,
                         ionpot_ev=ionpot_ev,
                         J=J,
@@ -972,18 +1026,18 @@ class SpencerFanoSolver:
                     N_e_ion += self._integrate_shell_secondaries(
                         arr_e_p=arr_e_p_low,
                         arr_y=np.asarray(np.interp(arr_e_p_low, self.engrid, self.yvec, left=0.0, right=0.0)),
-                        arr_xs=pynonthermal.collion.get_arxs_array_shell(arr_e_p_low, shell),
+                        arr_xs=channel.xs(arr_e_p_low),
                         e_s=energy_ev,
                         ionpot_ev=ionpot_ev,
                         J=J,
                     )
-                    # the rest is smooth on the scale of J, so y and the cross section come straight
-                    # from the solution and the cache rather than being re-evaluated
+                    # the rest is smooth on the scale of J, so y comes from the solution and the
+                    # cross section from the on-grid array of the channel, with no new evaluation
                     if stopindex < len(self.engrid) - 1:
                         N_e_ion += self._integrate_shell_secondaries(
                             arr_e_p=self.engrid[stopindex:],
                             arr_y=self.yvec[stopindex:],
-                            arr_xs=self._get_shell_xs(shell)[stopindex:],
+                            arr_xs=channel.xs_grid[stopindex:],
                             e_s=energy_ev,
                             ionpot_ev=ionpot_ev,
                             J=J,
@@ -1068,10 +1122,10 @@ class SpencerFanoSolver:
         for Z, ion_stage in self._get_all_ions():
             n_ion = self.ionpopdict.get((Z, ion_stage), 0.0)
             X_ion = n_ion / n_ion_tot if n_ion_tot > 0.0 else 0.0
-            # an ion added only for excitation has no ionisation shells in the matrix
-            collionrows = self._get_ion_collion_rows(Z, ion_stage) if (Z, ion_stage) in self._ionisation_ions else []
+            # an ion added only for excitation has no ionisation channels in the matrix
+            channels = self._ionisation_channels.get((Z, ion_stage), [])
 
-            ionpot_valence = min((float(shell["ionpot_ev"]) for shell in collionrows), default=None)
+            ionpot_valence = min((channel.ionpot_ev for channel in channels), default=None)
 
             if self.verbose:
                 valencestr = (
@@ -1084,30 +1138,21 @@ class SpencerFanoSolver:
 
             self._frac_ionisation_ion[(Z, ion_stage)] = 0.0
             eta_over_ionpot_sum = 0.0
-            for shell in collionrows:
-                ar_xs_array = self._get_shell_xs(shell)
+            for channel in channels:
+                ar_xs_array = channel.xs_grid
 
-                # the shell's part of the ionisation fraction eta_ic of Kozma & Fransson 1992
+                # the channel's part of the ionisation fraction eta_ic of Kozma & Fransson 1992
                 # equation 10: n_ion * ionpot * the integral of y(E) sigma_ic(E) dE, divided
                 # by the deposition rate density
                 frac_ionisation_shell = (
-                    n_ion
-                    * shell["ionpot_ev"]
-                    * np.dot(self.yvec, ar_xs_array)
-                    * deltaen
-                    / self.depositionratedensity_ev
+                    n_ion * channel.ionpot_ev * np.dot(self.yvec, ar_xs_array) * deltaen / self.depositionratedensity_ev
                 )
 
                 if self.verbose:
-                    if int(shell["n"]) < 0:
-                        strsubshell = SUBSHELLNAMES[-int(shell["l"])]
-                        shellname = f"Lotz shell {strsubshell}"
-                    else:
-                        shellname = f"n {int(shell['n']):d} l {int(shell['l']):d}"
                     print(
-                        f"frac_ionisation_shell({shellname}):"
+                        f"frac_ionisation_shell({channel.key}):"
                         f" {frac_ionisation_shell:.4f} (ionpot"
-                        f" {shell['ionpot_ev']:.2f} eV)"
+                        f" {channel.ionpot_ev:.2f} eV)"
                     )
 
                 # the heating-only approximation lets the fractions exceed one, so in that mode
@@ -1121,7 +1166,7 @@ class SpencerFanoSolver:
                     )
 
                 self._frac_ionisation_ion[(Z, ion_stage)] += frac_ionisation_shell
-                eta_over_ionpot_sum += frac_ionisation_shell / shell["ionpot_ev"]
+                eta_over_ionpot_sum += frac_ionisation_shell / channel.ionpot_ev
 
             self._frac_ionisation_tot += self._frac_ionisation_ion[(Z, ion_stage)]
 
@@ -1279,9 +1324,9 @@ class SpencerFanoSolver:
         add_ion_ltepopexcitation() it is (lower level index, upper level index).
         """
         self._require_solved()
-        _levelnumberdensity, xsvec, _epsilon_trans_ev = self.excitationlists[(Z, ion_stage)][transitionkey]
+        trans = self.excitationlists[(Z, ion_stage)][transitionkey]
 
-        return float(np.dot(xsvec, self.yvec) * self.deltaen)
+        return float(np.dot(trans.xs_vec, self.yvec) * self.deltaen)
 
     def get_frac_sum(self) -> float:
         return self.get_frac_heating() + self.get_frac_excitation_tot() + self.get_frac_ionisation_tot()
@@ -1298,12 +1343,10 @@ class SpencerFanoSolver:
         part_integrand = np.zeros(len(self.engrid))
 
         for Z, ion_stage in self.excitationlists:
-            for (
-                levelnumberdensity,
-                xsvec,
-                epsilon_trans_ev,
-            ) in self.excitationlists[(Z, ion_stage)].values():
-                part_integrand += levelnumberdensity * epsilon_trans_ev * xsvec / self.depositionratedensity_ev
+            for trans in self.excitationlists[(Z, ion_stage)].values():
+                part_integrand += (
+                    trans.levelnumberdensity * trans.epsilon_trans_ev * trans.xs_vec / self.depositionratedensity_ev
+                )
 
         return self.yvec * part_integrand
 
@@ -1311,13 +1354,11 @@ class SpencerFanoSolver:
         self._require_solved()
         part_integrand = np.zeros(len(self.engrid))
 
-        for Z, ion_stage in self._ionisation_ions:
+        for (Z, ion_stage), channels in self._ionisation_channels.items():
             n_ion = self.ionpopdict[(Z, ion_stage)]
 
-            for shell in self._get_ion_collion_rows(Z, ion_stage):
-                xsvec = self._get_shell_xs(shell)
-
-                part_integrand += n_ion * shell["ionpot_ev"] * xsvec / self.depositionratedensity_ev
+            for channel in channels:
+                part_integrand += n_ion * channel.ionpot_ev * channel.xs_grid / self.depositionratedensity_ev
 
         return self.yvec * part_integrand
 

--- a/pynonthermal/spencerfano.py
+++ b/pynonthermal/spencerfano.py
@@ -698,7 +698,7 @@ class SpencerFanoSolver:
         exactly zero is skipped without being registered. A ValueError is raised if any shell's
         ionisation potential lies below the energy grid's emin_ev (the message gives the emin_ev
         to use instead). To add a channel that the built-in table does not hold, or to replace the
-        built-in shells of an ion, use add_ionisation_table() instead.
+        built-in shells of an ion, use add_ionisation_channel() instead.
 
         n_ion:
             the ion number density in cm^-3

--- a/pynonthermal/tests/test_regressions.py
+++ b/pynonthermal/tests/test_regressions.py
@@ -410,9 +410,9 @@ def test_excitation_xs_zero_above_grid() -> None:
         sf.add_ionisation(26, 3, n_ion=0.7)
         sf.add_ion_ltepopexcitation(26, 3, n_ion=0.7)
         for transitions in sf.excitationlists.values():
-            for _levelpop, xs_vec, epsilon_trans_ev in transitions.values():
-                assert epsilon_trans_ev <= sf.engrid[-1]
-                assert (xs_vec >= 0.0).all()
+            for trans in transitions.values():
+                assert trans.epsilon_trans_ev <= sf.engrid[-1]
+                assert (trans.xs_vec >= 0.0).all()
 
 
 def test_excitation_only_ion_counted() -> None:
@@ -587,16 +587,16 @@ def test_excitation_band_fill_matches_rowwise() -> None:
 
 
 def _reference_ionisation_fill(
-    sf: pynonthermal.SpencerFanoSolver, n_ion: float, shell: dict[str, int | float]
+    sf: pynonthermal.SpencerFanoSolver, n_ion: float, channel: pynonthermal.IonisationChannel
 ) -> npt.NDArray[np.float64]:
-    # the masked full-tail construction of one shell's matrix contribution that predates the
+    # the masked full-tail construction of one channel's matrix contribution that predates the
     # forward-only cut pointers, kept verbatim as the reference the slice fill must reproduce
     engrid = sf.engrid
     npts = len(engrid)
     deltaen = sf.deltaen
-    ionpot_ev = float(shell["ionpot_ev"])
-    J = pynonthermal.collion.get_J(int(shell["Z"]), int(shell["ion_stage"]), ionpot_ev)
-    ar_xs_array = sf._get_shell_xs(shell)
+    ionpot_ev = channel.ionpot_ev
+    J = channel.J_ev
+    ar_xs_array = channel.xs_grid
     xsstartindex = 0 if ionpot_ev <= engrid[0] else sf.get_energyindex_gteq(en_ev=ionpot_ev)
     atan_epsilon = np.arctan((engrid - ionpot_ev) / 2.0 / J)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -636,13 +636,13 @@ def test_ltepop_excitation_grouped_fill() -> None:
         sf.add_ion_ltepopexcitation(2, 1, n_ion=1.0, use_collstrengths=False)
         assert len(sf.excitationlists[(2, 1)]) > 100  # the grouping must actually see many transitions
         expected = np.zeros((npts, npts))
-        for levelnumberdensity, xs_vec, epsilon_trans_ev in sf.excitationlists[(2, 1)].values():
-            expected += _reference_excitation_fill(sf, levelnumberdensity, xs_vec, epsilon_trans_ev)
+        for trans in sf.excitationlists[(2, 1)].values():
+            expected += _reference_excitation_fill(sf, trans.levelnumberdensity, trans.xs_vec, trans.epsilon_trans_ev)
         assert np.allclose(sf.sfmatrix, expected, rtol=1e-12, atol=0.0)
 
 
 def test_ionisation_fill_matches_masked_reference() -> None:
-    # _add_ionisation_shell writes only each row's non-empty integral range, located by
+    # _add_ionisation_channel_to_matrix writes only each row's non-empty integral range, located by
     # forward-only cut pointers that evaluate the same comparisons the per-row np.where masks
     # used. The resulting matrix must be bit-identical to the masked full-tail construction.
     for emin, emax, npts, Z, ion_stage in [
@@ -654,8 +654,8 @@ def test_ionisation_fill_matches_masked_reference() -> None:
             n_ion = 1e5
             sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
             expected = np.zeros((npts, npts))
-            for shell in sf._get_ion_collion_rows(Z, ion_stage):
-                expected += _reference_ionisation_fill(sf, n_ion, shell)
+            for channel in sf._ionisation_channels[(Z, ion_stage)]:
+                expected += _reference_ionisation_fill(sf, n_ion, channel)
             assert sf.sfmatrix.tobytes() == expected.tobytes(), f"mismatch for {Z=} {ion_stage=}"
 
 
@@ -685,3 +685,261 @@ def test_solve_upper_triangular_diag_add() -> None:
 
     with pytest.raises(ValueError, match="finite"):
         spencerfano.solve_upper_triangular(a, b, diag_add=np.array([math.nan] + [0.0] * (n - 1)))
+
+
+def _bethe_xs_grid(
+    engrid: npt.NDArray[np.float64], ionpot_ev: float, scale_cm2_ev2: float = 3e-13
+) -> npt.NDArray[np.float64]:
+    # a plain Bethe-like cross section [cm^2] on the solver energy grid, which stands for a custom
+    # cross section. It is zero at and below the ionisation potential, as every channel must be.
+    out = np.zeros_like(engrid)
+    above = engrid > ionpot_ev
+    out[above] = scale_cm2_ev2 * np.log(engrid[above] / ionpot_ev) / (engrid[above] * ionpot_ev)
+    return out
+
+
+def test_custom_ionisation_channel_matches_the_builtin_path() -> None:
+    # a custom channel must take exactly the same path as a shell of the built-in table. Adding the
+    # built-in cross sections back one call at a time must give the same matrix, bit for bit, and
+    # the same energy fractions after the solve.
+    Z, ion_stage, n_ion = 8, 2, 1e8
+    shells = (
+        pynonthermal.collion.read_colliondata()
+        .filter((pl.col("Z") == Z) & (pl.col("ion_stage") == ion_stage))
+        .to_dicts()
+    )
+    assert len(shells) > 1  # the ion must have more than one shell for this to mean anything
+
+    with (
+        pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=300) as sf_custom,
+        pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=300) as sf_builtin,
+    ):
+        sf_builtin.add_ionisation(Z, ion_stage, n_ion=n_ion)
+        for shell in shells:
+            sf_custom.add_ionisation_channel(
+                Z,
+                ion_stage,
+                n_ion=n_ion,
+                ionpot_ev=float(shell["ionpot_ev"]),
+                xs_vec=pynonthermal.collion.get_arxs_array_shell(sf_custom.engrid, shell),
+            )
+
+        assert sf_custom.sfmatrix.tobytes() == sf_builtin.sfmatrix.tobytes()
+
+        for sf in (sf_custom, sf_builtin):
+            sf.solve(depositionratedensity_ev=1e8)
+
+        assert math.isclose(
+            sf_custom.get_frac_ionisation_ion(Z, ion_stage), sf_builtin.get_frac_ionisation_ion(Z, ion_stage)
+        )
+        # frac_heating differs only through calculate_N_e, which needs the cross section between
+        # the grid points and interpolates the array there instead of using the exact formula
+        assert math.isclose(sf_custom.get_frac_heating(), sf_builtin.get_frac_heating(), rel_tol=1e-5)
+
+
+def test_custom_ionisation_channel_conserves_energy() -> None:
+    # the whole custom path, from the matrix fill to calculate_N_e, must still put every
+    # deposited eV into heating, excitation, or ionisation
+    ionpot_ev = 35.0
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=2000) as sf:
+        sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=ionpot_ev, xs_vec=_bethe_xs_grid(sf.engrid, ionpot_ev))
+        sf.solve(depositionratedensity_ev=1e8)
+
+        assert sf.get_frac_ionisation_tot() > 0.1  # the channel must carry a real share
+        assert math.isclose(sf.get_frac_sum(), 1.0, abs_tol=0.01)
+
+        # calculate_N_e integrates over a domain narrower than one grid cell just above the
+        # ionisation potential, so the channel must give values between the grid points
+        channel = sf._ionisation_channels[(8, 2)][0]
+        off_grid = np.array([ionpot_ev * 1.001, ionpot_ev * 1.002, ionpot_ev * 1.003])
+        assert not np.isin(off_grid, sf.engrid).any()
+        assert (channel.xs(off_grid) > 0.0).all()
+        # and it stays at zero below its own ionisation potential
+        assert not channel.xs(np.array([ionpot_ev * 0.999, ionpot_ev])).any()
+
+
+def test_custom_ionisation_channel_adds_to_the_builtin_shells() -> None:
+    # add_ionisation() and add_ionisation_channel() may both be called for one ion
+    Z, ion_stage, n_ion = 8, 2, 1e8
+    with (
+        pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=300) as sf_builtin,
+        pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=300) as sf_extra,
+    ):
+        for sf in (sf_builtin, sf_extra):
+            sf.add_ionisation(Z, ion_stage, n_ion=n_ion)
+        sf_extra.add_ionisation_channel(
+            Z,
+            ion_stage,
+            n_ion=n_ion,
+            ionpot_ev=120.0,
+            xs_vec=_bethe_xs_grid(sf_extra.engrid, 120.0),
+            channelkey="my inner shell",
+        )
+
+        assert (
+            len(sf_extra._ionisation_channels[(Z, ion_stage)])
+            == len(sf_builtin._ionisation_channels[(Z, ion_stage)]) + 1
+        )
+        for sf in (sf_builtin, sf_extra):
+            sf.solve(depositionratedensity_ev=1e8)
+        assert sf_extra.get_frac_ionisation_ion(Z, ion_stage) > sf_builtin.get_frac_ionisation_ion(Z, ion_stage)
+
+
+def test_custom_ionisation_channel_validation() -> None:
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=200) as sf:
+        good = _bethe_xs_grid(sf.engrid, 35.0)
+
+        # the cross section must be non-negative, finite, and on the whole grid
+        with pytest.raises(ValueError, match="non-negative"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=35.0, xs_vec=-good)
+        with pytest.raises(ValueError, match="finite"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=35.0, xs_vec=np.full_like(good, np.inf))
+        with pytest.raises(ValueError, match="one value for each"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=35.0, xs_vec=good[:-1])
+
+        # a cross section below the ionisation potential would count towards the ionisation
+        # fraction without a matching loss term in the matrix
+        with pytest.raises(ValueError, match="zero at and below its ionisation potential"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=35.0, xs_vec=np.full_like(good, 1e-18))
+
+        # the ionisation potential must lie inside the energy grid
+        with pytest.raises(ValueError, match="below emin_ev"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=0.5, xs_vec=_bethe_xs_grid(sf.engrid, 0.5))
+        with pytest.raises(ValueError, match="above the top of the energy grid"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=5000.0, xs_vec=np.zeros_like(good))
+        with pytest.raises(ValueError, match="ionpot_ev must be greater than zero"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=-1.0, xs_vec=np.zeros_like(good))
+
+        # a nan or infinite population used to reach ionpopdict and make every result nan
+        for bad in (float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="non-negative and finite"):
+                sf.add_ionisation_channel(8, 2, n_ion=bad, ionpot_ev=35.0, xs_vec=good)
+            with pytest.raises(ValueError, match="non-negative and finite"):
+                sf.add_ionisation(8, 2, n_ion=bad)
+
+        # ion_stage below one gives a negative charge, which only a bare assert used to catch
+        with pytest.raises(ValueError, match="ion_stage must be at least 1"):
+            sf.add_ionisation_channel(8, 0, n_ion=1e8, ionpot_ev=35.0, xs_vec=good)
+        with pytest.raises(ValueError, match="Z must be at least 1"):
+            sf.add_ionisation_channel(0, 1, n_ion=1e8, ionpot_ev=35.0, xs_vec=good)
+
+        assert not sf.ionpopdict
+        assert not sf._ionisation_channels
+
+        # a zero population adds no channel, but the cross section is still checked
+        with pytest.raises(ValueError, match="non-negative"):
+            sf.add_ionisation_channel(8, 2, n_ion=0.0, ionpot_ev=35.0, xs_vec=-good)
+        sf.add_ionisation_channel(8, 2, n_ion=0.0, ionpot_ev=35.0, xs_vec=good)
+        assert (8, 2) not in sf.ionpopdict
+        assert not sf.sfmatrix.any()
+
+        # an omitted channelkey gets an automatic index, and a duplicate key is rejected
+        sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=35.0, xs_vec=good)
+        assert sf._ionisation_channels[(8, 2)][0].key == 0
+        with pytest.raises(ValueError, match="already added"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=35.0, xs_vec=good, channelkey=0)
+        # the population must agree with the one an earlier call for this ion gave
+        with pytest.raises(ValueError, match="different populations"):
+            sf.add_ionisation_channel(8, 2, n_ion=2e8, ionpot_ev=42.0, xs_vec=_bethe_xs_grid(sf.engrid, 42.0))
+
+        sf.solve(depositionratedensity_ev=1e8)
+        with pytest.raises(RuntimeError, match="after solving"):
+            sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=60.0, xs_vec=good)
+
+
+def test_add_ionisation_is_atomic() -> None:
+    # a key clash inside add_ionisation must leave the solver exactly as it was, so that the
+    # caller can correct the key and try again
+    Z, ion_stage = 8, 2
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=150) as sf:
+        # "n 2 l 0" is the second built-in shell of O II, so the clash comes after the first
+        sf.add_ionisation_channel(
+            Z,
+            ion_stage,
+            n_ion=1e8,
+            ionpot_ev=42.6,
+            xs_vec=_bethe_xs_grid(sf.engrid, 42.6),
+            channelkey="n 2 l 0",
+        )
+        matrix_before = sf.sfmatrix.copy()
+
+        with pytest.raises(ValueError, match="already added"):
+            sf.add_ionisation(Z, ion_stage, n_ion=1e8)
+
+        assert np.array_equal(sf.sfmatrix, matrix_before)
+        assert [channel.key for channel in sf._ionisation_channels[(Z, ion_stage)]] == ["n 2 l 0"]
+
+        # the ion is not poisoned: a call with a free key still works
+        sf.add_ionisation_channel(Z, ion_stage, n_ion=1e8, ionpot_ev=35.1, xs_vec=_bethe_xs_grid(sf.engrid, 35.1))
+        assert len(sf._ionisation_channels[(Z, ion_stage)]) == 2
+
+
+def test_cross_sections_are_copied_from_the_caller() -> None:
+    # the solver keeps a read-only copy of every cross section, so a later write by the caller
+    # cannot silently change the physics it already recorded
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=300) as sf:
+        xs_vec = np.where(sf.engrid >= 20.0, 1e-16, 0.0)
+        sf.add_excitation(8, 2, levelnumberdensity=1e8, xs_vec=xs_vec, epsilon_trans_ev=20.0)
+        xs_vec[:] = 0.0
+        assert sf.excitationlists[(8, 2)][0].xs_vec.max() > 0.0
+        assert not sf.excitationlists[(8, 2)][0].xs_vec.flags.writeable
+
+        ion_xs = _bethe_xs_grid(sf.engrid, 35.0)
+        sf.add_ionisation_channel(8, 2, n_ion=1e8, ionpot_ev=35.0, xs_vec=ion_xs)
+        ion_xs[:] = 0.0
+        channel = sf._ionisation_channels[(8, 2)][0]
+        assert channel.xs_grid.max() > 0.0
+        assert not channel.xs_grid.flags.writeable
+        # the interpolation the channel uses off the grid kept the copy too
+        assert channel.xs(np.array([100.5]))[0] > 0.0
+
+    # the built-in shells of one ion must not share an array
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=300) as sf_builtin:
+        sf_builtin.add_ionisation(8, 2, n_ion=1e8)
+        channels = sf_builtin._ionisation_channels[(8, 2)]
+        assert len(channels) > 1
+        assert not np.shares_memory(channels[0].xs_grid, channels[1].xs_grid)
+
+
+def test_engrid_is_read_only() -> None:
+    # deltaen is derived from engrid once, so a write in place would leave the two inconsistent
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=100) as sf:
+        assert not sf.engrid.flags.writeable
+        with pytest.raises(ValueError, match="read-only"):
+            sf.engrid[0] = 2.0
+        assert sf.engrid[0] == 1.0
+
+
+def test_excitation_xs_must_be_finite() -> None:
+    # an infinite cross section used to pass the non-negative test and put inf into the matrix
+    with pynonthermal.SpencerFanoSolver(emin_ev=1, emax_ev=3000, npts=100) as sf:
+        xs_vec = np.zeros(100)
+        xs_vec[50:] = np.inf
+        with pytest.raises(ValueError, match="finite"):
+            sf.add_excitation(8, 2, levelnumberdensity=1e8, xs_vec=xs_vec, epsilon_trans_ev=20.0)
+        assert not sf.sfmatrix.any()
+
+        # a cross section of the wrong shape is named, rather than reaching the matrix band
+        with pytest.raises(ValueError, match="one value for each"):
+            sf.add_excitation(8, 2, levelnumberdensity=1e8, xs_vec=np.zeros((100, 1)), epsilon_trans_ev=20.0)
+        assert not sf.excitationlists.get((8, 2))
+
+
+def test_every_builtin_ion_builds_channels() -> None:
+    # the checks in IonisationChannel.from_xs must accept every row of the built-in tables, on both
+    # the Arnaud & Rothenflug fit branch and the Lotz branch
+    engrid = np.linspace(1.0, 3000.0, num=64, dtype=np.float64)
+    for collionfilename in ("collion.txt", "collion-AR1985.txt"):
+        dfcollion = pynonthermal.collion.read_colliondata(collionfilename)
+        n_lotz = 0
+        n_fit = 0
+        for Z, ion_stage in dfcollion.select(["Z", "ion_stage"]).unique().iter_rows():
+            channels = pynonthermal.collion.get_ion_ionisation_channels(dfcollion, Z, ion_stage, engrid)
+            assert channels
+            for channel in channels:
+                if str(channel.key).startswith("Lotz"):
+                    n_lotz += 1
+                else:
+                    n_fit += 1
+        assert n_lotz > 0
+        assert n_fit > 0

--- a/pynonthermal/tests/test_sfsolve.py
+++ b/pynonthermal/tests/test_sfsolve.py
@@ -45,8 +45,8 @@ def test_api_guards() -> None:
         with pytest.raises(RuntimeError):
             sf.get_excitation_ratecoeff(2, 1, 0)
 
-        # the same ion can't be added twice
-        with pytest.raises(ValueError, match="twice"):
+        # the same ion can't be added twice: its channel keys are already present
+        with pytest.raises(ValueError, match="already added"):
             sf.add_ionisation(2, 1, n_ion=1.0)
 
         # an ion with no cross-section data (here H II, which has no bound electrons) is rejected


### PR DESCRIPTION
## Why

An atomic physicist who wants to test a new cross section could not do it. `add_excitation()` took an array, but `add_ionisation()` gave no entry point at all: it read every shell from the built-in table and applied the built-in formula. The only knob was the choice between two packaged data files.

## What changed

**New: `add_ionisation_channel(Z, ion_stage, n_ion, ionpot_ev, xs_vec, channelkey=None)`** — one ionisation channel with a custom cross section and an arbitrary ionisation potential. The cross section is an array in cm^2 at every energy of `sf.engrid`, exactly as `add_excitation()` takes one. Call it once per channel; mix it with `add_ionisation()` to add to the built-in shells, or omit `add_ionisation()` to replace them.

**Built-in shells and custom channels now share one code path.** An `IonisationChannel` record holds the ionisation potential, the cross section on the grid, the secondary-electron width `J`, and a key. It replaces three private solver members: the per-shell cross-section cache, the per-ion table-filter cache, and the set of ions with ionisation. The first could not be extended, because its cache key `(Z, ion_stage, n, l, ionpot_ev)` cannot describe a channel that is not a subshell.

`IonisationChannel.from_xs()` validates each cross section. Its check that the cross section is zero at and below the ionisation potential is load-bearing: the matrix fill starts at the potential but `analyse_ntspectrum()` integrates the whole grid, so anything below it would add to the ionisation fraction with no matching loss term and quietly break the energy fractions.

**A channel holds a function, not just an array.** `calculate_N_e()` integrates over a domain just above the ionisation potential that is narrower than one grid cell, so it evaluates the cross section between the grid points. A built-in channel uses the exact formula; a custom channel interpolates its own array. Measured against the exact formula for O II:

| npts | matrix | frac_ionisation | frac_heating |
|---|---|---|---|
| 300 | bit-identical | identical | 9.8e-08 |
| 4096 | bit-identical | identical | 1.2e-10 |

The difference reaches `frac_heating` only through the sub-`emin_ev` term, which is itself ~5e-5 of the total.

## Breaking change

`SpencerFanoSolver.excitationlists` values change from the bare 3-tuple `(levelnumberdensity, xs_vec, epsilon_trans_ev)` to an `ExcitationTransition` record. Code that unpacks the tuple needs `.levelnumberdensity`, `.xs_vec`, `.epsilon_trans_ev` instead. No in-repo caller or notebook was affected; `artistools` only calls `add_ionisation()` positionally, which stays compatible.

## Fixes found while reviewing this change

- **`np.asarray` does not copy.** A cross section that reused one scratch buffer made every channel of an ion share it, giving a 32% error in `frac_ionisation` with no warning — `frac_sum` stayed at 1.004, so the conservation check missed it. Both cross sections are now copied and held read-only.
- **The excitation check said "non-negative and finite" but tested only the sign**, so `+inf` reached the matrix and failed later with an unrelated message.
- **`add_ionisation()` was not atomic.** A channel-key clash left the ion half-added and permanently unretryable behind a misleading "twice" message. Every key is now checked before any channel is stored.
- **A `n_ion` of nan or inf passed every guard** and made every result nan; an `ion_stage` below 1 gave a bare `AssertionError` at solve time. Both now raise where they happen.
- **`engrid` was writeable**, so a cross section that operated in place corrupted the grid and left `deltaen` stale.

## Verification

Built-in results are unchanged. The matrix fill is bit-identical to `main` across **every ion of both collion tables on four energy grids (45,625 `add_ionisation()` calls)**, and the pinned helium and iron values in `test_sfsolve.py` are untouched. `get_d_etaion_by_d_en_vec()` moves by up to 5 ULP because the ion loop changed from set order to dict order; it feeds only `plot_channels()`, and against an `fsum` reference the new order is marginally more accurate.

42 tests pass (11 new). `ruff check`, `ruff format`, `pyrefly` and `ty` are clean. No measurable performance change: 10 ions at npts=4096 runs within 2% of `main`.

## For the reviewer

- The secondary-electron distribution keeps the Kozma & Fransson (1992) Lorentzian shape and the `get_J()` width. The matrix fill integrates it analytically through its arctan antiderivative, so an arbitrary shape would need numerical quadrature in every matrix cell. The width is per-channel; the shape is fixed, and the docstrings say so.
- A custom channel's `ionpot_ev` is free, so a channel need not be a subshell — a total ionisation cross section for an ion works.
- Deliberately **not** included, after weighing them: formula hooks on `add_ionisation()` and `add_ion_ltepopexcitation()`, and a custom `dfcollion` table. They were speculative given that cross sections arrive as data, and the A–D fit coefficients they would have exposed are the sentinel `-1.0` for 96.6% of ions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
